### PR TITLE
Version update highlight

### DIFF
--- a/Switch Backup Manager/FileData.cs
+++ b/Switch Backup Manager/FileData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Switch_Backup_Manager
 {
@@ -139,10 +140,14 @@ namespace Switch_Backup_Manager
         public string NumberOfPlayers { get; set; }
         public List<string> Categories { get; set; }
         public int ESRB { get; set; }
-
         public string Source { get; set; }
 
         //Available at runtime only
         public string sceneFound { get; set; }
+
+        public bool isLatest()
+        {
+            return Double.TryParse(this.Version, out double currentVersion) && Double.TryParse(this.Latest, out double currentLatest) && currentVersion >= currentLatest;
+        }
     }
 }

--- a/Switch Backup Manager/Form1.Designer.cs
+++ b/Switch Backup Manager/Form1.Designer.cs
@@ -47,7 +47,7 @@
             this.PB_GameIcon = new System.Windows.Forms.PictureBox();
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             this.tabControl1 = new System.Windows.Forms.TabControl();
-            this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.tabPageXCI = new System.Windows.Forms.TabPage();
             this.panel2 = new System.Windows.Forms.Panel();
             this.OLVLocalFiles = new BrightIdeasSoftware.ObjectListView();
             this.olvColumnTitleIDLocal = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
@@ -106,14 +106,14 @@
             this.noneToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.invertSelectionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            this.eshopReleasesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.itemsOnEshjToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.itensToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.itemsOnSDCardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.itemsNotOnSDCardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.sceneReleasesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.itemsOnSceneReleasesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.itemsNotOnSceneReleasesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.eshopReleasesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.itemsOnEshjToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.listToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.noneToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.gameTitleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -153,7 +153,95 @@
             this.exportGameListToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.htmlToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.cSVToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.tabPage2 = new System.Windows.Forms.TabPage();
+            this.tabPageNSP = new System.Windows.Forms.TabPage();
+            this.panel10 = new System.Windows.Forms.Panel();
+            this.OLVEshop = new BrightIdeasSoftware.ObjectListView();
+            this.olvColumnTitleIDEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnGameNameEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnROMSizeEshop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnLanguagesEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnFilePathEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnDeveloperEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnPublisherEshop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnGameRevisionEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnVersionEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnLatestEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnMasterKeyRevisionEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnDistributionType = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnFirmwareEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnSDKVersionEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnReleaseDateEshop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnNumberOfPlayersEshop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnCategoriesEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnContentTypeEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnImportedDateEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnSourceEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.contextMenuEShopList = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.toolStripMenuItemEShopShowInExplorer = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemEShopUpdateInfo = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripMenuItemEShopAutoRename = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripMenuItemEShopCopyToFolder = new System.Windows.Forms.ToolStripMenuItem();
+            this.sDCardToolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
+            this.folderToolStripMenuItem5 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemEShopMoveToFolder = new System.Windows.Forms.ToolStripMenuItem();
+            this.sDCardToolStripMenuItem5 = new System.Windows.Forms.ToolStripMenuItem();
+            this.folderToolStripMenuItem6 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem64 = new System.Windows.Forms.ToolStripSeparator();
+            this.copyInfoToClipboardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.updateGameInfoFromWebToolStripMenuItemEshop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem97Eshop = new System.Windows.Forms.ToolStripSeparator();
+            this.deleteSelectedFilesToolStripMenuItemEshop = new System.Windows.Forms.ToolStripMenuItem();
+            this.panel11 = new System.Windows.Forms.Panel();
+            this.panel13 = new System.Windows.Forms.Panel();
+            this.cbBaseGame = new System.Windows.Forms.CheckBox();
+            this.cbUpdates = new System.Windows.Forms.CheckBox();
+            this.cbDLC = new System.Windows.Forms.CheckBox();
+            this.btnClearFilterEShop = new System.Windows.Forms.Button();
+            this.textBoxFilterEShop = new System.Windows.Forms.TextBox();
+            this.label5 = new System.Windows.Forms.Label();
+            this.cbxFilterEshop = new System.Windows.Forms.ComboBox();
+            this.panel12 = new System.Windows.Forms.Panel();
+            this.menuEShop = new System.Windows.Forms.MenuStrip();
+            this.addToolStripMenuItemAddFolderEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.filesToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.folderToolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemSelectEshop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemSelectAllEshop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemSelectNoneEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemSelectInvertEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripMenuItemSelectSDCardEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemSelectSDCardItemsOnSDEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemSelectSceneEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemSelectSceneOnEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemSelectSceneNotOnEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem97 = new System.Windows.Forms.ToolStripSeparator();
+            this.outdatedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem22 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemGroupingNoneEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemGroupingGameTitleEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemGroupingDeveloperEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemGroupingMasterKeyEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem23 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemRemoveSelectedEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripMenuItem44 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemRemoveFilesOnSDCardEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemRemoveFilesNotOnSDCardEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem65 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem66 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem67 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem24 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem45 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemCopyFilesToSDEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemMoveFilesToSDEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem69 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemCopyFilesToFolderEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemMoveFilesToFolderEShop = new System.Windows.Forms.ToolStripMenuItem();
+            this.tabPageSD = new System.Windows.Forms.TabPage();
             this.btnClearFilterSD = new System.Windows.Forms.Button();
             this.textBoxFilterSD = new System.Windows.Forms.TextBox();
             this.label3 = new System.Windows.Forms.Label();
@@ -244,7 +332,7 @@
             this.toolStripMenuItem47 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem48 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem49 = new System.Windows.Forms.ToolStripMenuItem();
-            this.tabPage3 = new System.Windows.Forms.TabPage();
+            this.tabPageScene = new System.Windows.Forms.TabPage();
             this.panel4 = new System.Windows.Forms.Panel();
             this.btnClearFilterScene = new System.Windows.Forms.Button();
             this.textBoxFilterScene = new System.Windows.Forms.TextBox();
@@ -316,95 +404,7 @@
             this.toolStripMenuItem93 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem94 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem95 = new System.Windows.Forms.ToolStripMenuItem();
-            this.tabPage4 = new System.Windows.Forms.TabPage();
-            this.panel10 = new System.Windows.Forms.Panel();
-            this.OLVEshop = new BrightIdeasSoftware.ObjectListView();
-            this.olvColumnTitleIDEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnGameNameEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnROMSizeEshop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnLanguagesEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnFilePathEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnDeveloperEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnPublisherEshop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnGameRevisionEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnVersionEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnLatestEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnMasterKeyRevisionEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnDistributionType = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnFirmwareEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnSDKVersionEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnReleaseDateEshop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnNumberOfPlayersEshop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnCategoriesEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnContentTypeEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnImportedDateEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnSourceEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.contextMenuEShopList = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.toolStripMenuItemEShopShowInExplorer = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemEShopUpdateInfo = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripMenuItemEShopAutoRename = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripMenuItemEShopCopyToFolder = new System.Windows.Forms.ToolStripMenuItem();
-            this.sDCardToolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
-            this.folderToolStripMenuItem5 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemEShopMoveToFolder = new System.Windows.Forms.ToolStripMenuItem();
-            this.sDCardToolStripMenuItem5 = new System.Windows.Forms.ToolStripMenuItem();
-            this.folderToolStripMenuItem6 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem64 = new System.Windows.Forms.ToolStripSeparator();
-            this.copyInfoToClipboardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.updateGameInfoFromWebToolStripMenuItemEshop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem97Eshop = new System.Windows.Forms.ToolStripSeparator();
-            this.deleteSelectedFilesToolStripMenuItemEshop = new System.Windows.Forms.ToolStripMenuItem();
-            this.panel11 = new System.Windows.Forms.Panel();
-            this.panel13 = new System.Windows.Forms.Panel();
-            this.cbBaseGame = new System.Windows.Forms.CheckBox();
-            this.cbUpdates = new System.Windows.Forms.CheckBox();
-            this.cbDLC = new System.Windows.Forms.CheckBox();
-            this.btnClearFilterEShop = new System.Windows.Forms.Button();
-            this.textBoxFilterEShop = new System.Windows.Forms.TextBox();
-            this.label5 = new System.Windows.Forms.Label();
-            this.cbxFilterEshop = new System.Windows.Forms.ComboBox();
-            this.panel12 = new System.Windows.Forms.Panel();
-            this.menuEShop = new System.Windows.Forms.MenuStrip();
-            this.addToolStripMenuItemAddFolderEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.filesToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.folderToolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemSelectEshop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemSelectAllEshop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemSelectNoneEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemSelectInvertEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripMenuItemSelectSDCardEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemSelectSDCardItemsOnSDEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemSelectSceneEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemSelectSceneOnEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemSelectSceneNotOnEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem97 = new System.Windows.Forms.ToolStripSeparator();
-            this.outdatedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem22 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemGroupingNoneEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemGroupingGameTitleEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemGroupingDeveloperEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemGroupingMasterKeyEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem23 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemRemoveSelectedEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripMenuItem44 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemRemoveFilesOnSDCardEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemRemoveFilesNotOnSDCardEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem65 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem66 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem67 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem24 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem45 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemCopyFilesToSDEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemMoveFilesToSDEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem69 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemCopyFilesToFolderEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItemMoveFilesToFolderEShop = new System.Windows.Forms.ToolStripMenuItem();
-            this.tabPage5 = new System.Windows.Forms.TabPage();
+            this.tabPageLog = new System.Windows.Forms.TabPage();
             this.panel6 = new System.Windows.Forms.Panel();
             this.richTextBoxLog = new System.Windows.Forms.RichTextBox();
             this.panel7 = new System.Windows.Forms.Panel();
@@ -415,9 +415,10 @@
             this.toolStripStatusFilesOperation = new System.Windows.Forms.ToolStripStatusLabel();
             this.toolStripProgressAddingFiles = new System.Windows.Forms.ToolStripProgressBar();
             this.toolStripStatusLabelGame = new System.Windows.Forms.ToolStripStatusLabel();
-            this.toolStripStatusLabel3 = new System.Windows.Forms.ToolStripStatusLabel();
-            this.toolStripStatusLabel4 = new System.Windows.Forms.ToolStripStatusLabel();
-            this.toolStripStatusLabel5 = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripStatusLabelFilesInXCI = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripStatusLabelFilesInNSP = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripStatusLabelFilesInBoth = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripStatusLabelVersion = new System.Windows.Forms.ToolStripStatusLabel();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -479,7 +480,7 @@
             this.splitContainer2.Panel2.SuspendLayout();
             this.splitContainer2.SuspendLayout();
             this.tabControl1.SuspendLayout();
-            this.tabPage1.SuspendLayout();
+            this.tabPageXCI.SuspendLayout();
             this.panel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.OLVLocalFiles)).BeginInit();
             this.contextMenuLocalList.SuspendLayout();
@@ -487,17 +488,7 @@
             this.panel9.SuspendLayout();
             this.panel8.SuspendLayout();
             this.menuLocalFiles.SuspendLayout();
-            this.tabPage2.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.OLV_SDCard)).BeginInit();
-            this.contextMenuStripSDCard.SuspendLayout();
-            this.panel5.SuspendLayout();
-            this.menuSDFiles.SuspendLayout();
-            this.tabPage3.SuspendLayout();
-            this.panel4.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.OLVSceneList)).BeginInit();
-            this.contextMenuStripScene.SuspendLayout();
-            this.menuStrip3.SuspendLayout();
-            this.tabPage4.SuspendLayout();
+            this.tabPageNSP.SuspendLayout();
             this.panel10.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.OLVEshop)).BeginInit();
             this.contextMenuEShopList.SuspendLayout();
@@ -505,7 +496,17 @@
             this.panel13.SuspendLayout();
             this.panel12.SuspendLayout();
             this.menuEShop.SuspendLayout();
-            this.tabPage5.SuspendLayout();
+            this.tabPageSD.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.OLV_SDCard)).BeginInit();
+            this.contextMenuStripSDCard.SuspendLayout();
+            this.panel5.SuspendLayout();
+            this.menuSDFiles.SuspendLayout();
+            this.tabPageScene.SuspendLayout();
+            this.panel4.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.OLVSceneList)).BeginInit();
+            this.contextMenuStripScene.SuspendLayout();
+            this.menuStrip3.SuspendLayout();
+            this.tabPageLog.SuspendLayout();
             this.panel6.SuspendLayout();
             this.panel7.SuspendLayout();
             this.statusStrip1.SuspendLayout();
@@ -573,7 +574,7 @@
             this.lnkInfo.Size = new System.Drawing.Size(328, 13);
             this.lnkInfo.TabIndex = 29;
             this.lnkInfo.TabStop = true;
-            this.lnkInfo.Text = "E-shop homepage";
+            this.lnkInfo.Text = "eShop Homepage";
             this.lnkInfo.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.lnkInfo.Visible = false;
             this.lnkInfo.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkInfo_LinkClicked);
@@ -726,11 +727,11 @@
             // 
             // tabControl1
             // 
-            this.tabControl1.Controls.Add(this.tabPage1);
-            this.tabControl1.Controls.Add(this.tabPage2);
-            this.tabControl1.Controls.Add(this.tabPage3);
-            this.tabControl1.Controls.Add(this.tabPage4);
-            this.tabControl1.Controls.Add(this.tabPage5);
+            this.tabControl1.Controls.Add(this.tabPageXCI);
+            this.tabControl1.Controls.Add(this.tabPageNSP);
+            this.tabControl1.Controls.Add(this.tabPageSD);
+            this.tabControl1.Controls.Add(this.tabPageScene);
+            this.tabControl1.Controls.Add(this.tabPageLog);
             this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tabControl1.Location = new System.Drawing.Point(0, 24);
             this.tabControl1.Name = "tabControl1";
@@ -740,17 +741,17 @@
             this.tabControl1.SelectedIndexChanged += new System.EventHandler(this.tabControl1_SelectedIndexChanged);
             this.tabControl1.TabIndexChanged += new System.EventHandler(this.tabControl1_TabIndexChanged);
             // 
-            // tabPage1
+            // tabPageXCI
             // 
-            this.tabPage1.Controls.Add(this.panel2);
-            this.tabPage1.Controls.Add(this.panel1);
-            this.tabPage1.Location = new System.Drawing.Point(4, 22);
-            this.tabPage1.Name = "tabPage1";
-            this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage1.Size = new System.Drawing.Size(1519, 368);
-            this.tabPage1.TabIndex = 0;
-            this.tabPage1.Text = "Local files";
-            this.tabPage1.UseVisualStyleBackColor = true;
+            this.tabPageXCI.Controls.Add(this.panel2);
+            this.tabPageXCI.Controls.Add(this.panel1);
+            this.tabPageXCI.Location = new System.Drawing.Point(4, 22);
+            this.tabPageXCI.Name = "tabPageXCI";
+            this.tabPageXCI.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPageXCI.Size = new System.Drawing.Size(1519, 368);
+            this.tabPageXCI.TabIndex = 0;
+            this.tabPageXCI.Text = "XCI Files";
+            this.tabPageXCI.UseVisualStyleBackColor = true;
             // 
             // panel2
             // 
@@ -1033,14 +1034,14 @@
             // sDCardToolStripMenuItem2
             // 
             this.sDCardToolStripMenuItem2.Name = "sDCardToolStripMenuItem2";
-            this.sDCardToolStripMenuItem2.Size = new System.Drawing.Size(180, 22);
-            this.sDCardToolStripMenuItem2.Text = "SD card";
+            this.sDCardToolStripMenuItem2.Size = new System.Drawing.Size(116, 22);
+            this.sDCardToolStripMenuItem2.Text = "SD Card";
             this.sDCardToolStripMenuItem2.Click += new System.EventHandler(this.sDCardToolStripMenuItem2_Click);
             // 
             // folderToolStripMenuItem2
             // 
             this.folderToolStripMenuItem2.Name = "folderToolStripMenuItem2";
-            this.folderToolStripMenuItem2.Size = new System.Drawing.Size(180, 22);
+            this.folderToolStripMenuItem2.Size = new System.Drawing.Size(116, 22);
             this.folderToolStripMenuItem2.Text = "Folder...";
             this.folderToolStripMenuItem2.Click += new System.EventHandler(this.folderToolStripMenuItem2_Click);
             // 
@@ -1057,7 +1058,7 @@
             // 
             this.sDCardToolStripMenuItem3.Name = "sDCardToolStripMenuItem3";
             this.sDCardToolStripMenuItem3.Size = new System.Drawing.Size(116, 22);
-            this.sDCardToolStripMenuItem3.Text = "SD card";
+            this.sDCardToolStripMenuItem3.Text = "SD Card";
             this.sDCardToolStripMenuItem3.Click += new System.EventHandler(this.sDCardToolStripMenuItem3_Click);
             // 
             // folderToolStripMenuItem3
@@ -1221,9 +1222,9 @@
             this.noneToolStripMenuItem,
             this.invertSelectionToolStripMenuItem,
             this.toolStripMenuItem1,
+            this.eshopReleasesToolStripMenuItem,
             this.itensToolStripMenuItem,
-            this.sceneReleasesToolStripMenuItem,
-            this.eshopReleasesToolStripMenuItem});
+            this.sceneReleasesToolStripMenuItem});
             this.selectToolStripMenuItem.Name = "selectToolStripMenuItem";
             this.selectToolStripMenuItem.Size = new System.Drawing.Size(50, 20);
             this.selectToolStripMenuItem.Text = "&Select";
@@ -1231,28 +1232,43 @@
             // allToolStripMenuItem
             // 
             this.allToolStripMenuItem.Name = "allToolStripMenuItem";
-            this.allToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.allToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
             this.allToolStripMenuItem.Text = "All";
             this.allToolStripMenuItem.Click += new System.EventHandler(this.allToolStripMenuItem_Click);
             // 
             // noneToolStripMenuItem
             // 
             this.noneToolStripMenuItem.Name = "noneToolStripMenuItem";
-            this.noneToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.noneToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
             this.noneToolStripMenuItem.Text = "None";
             this.noneToolStripMenuItem.Click += new System.EventHandler(this.noneToolStripMenuItem_Click);
             // 
             // invertSelectionToolStripMenuItem
             // 
             this.invertSelectionToolStripMenuItem.Name = "invertSelectionToolStripMenuItem";
-            this.invertSelectionToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.invertSelectionToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
             this.invertSelectionToolStripMenuItem.Text = "Invert selection";
             this.invertSelectionToolStripMenuItem.Click += new System.EventHandler(this.invertSelectionToolStripMenuItem_Click);
             // 
             // toolStripMenuItem1
             // 
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(152, 6);
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(151, 6);
+            // 
+            // eshopReleasesToolStripMenuItem
+            // 
+            this.eshopReleasesToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.itemsOnEshjToolStripMenuItem});
+            this.eshopReleasesToolStripMenuItem.Name = "eshopReleasesToolStripMenuItem";
+            this.eshopReleasesToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
+            this.eshopReleasesToolStripMenuItem.Text = "NSP Files";
+            // 
+            // itemsOnEshjToolStripMenuItem
+            // 
+            this.itemsOnEshjToolStripMenuItem.Name = "itemsOnEshjToolStripMenuItem";
+            this.itemsOnEshjToolStripMenuItem.Size = new System.Drawing.Size(159, 22);
+            this.itemsOnEshjToolStripMenuItem.Text = "Items in NSP list";
+            this.itemsOnEshjToolStripMenuItem.Click += new System.EventHandler(this.itemsOnEshjToolStripMenuItem_Click);
             // 
             // itensToolStripMenuItem
             // 
@@ -1260,8 +1276,8 @@
             this.itemsOnSDCardToolStripMenuItem,
             this.itemsNotOnSDCardToolStripMenuItem});
             this.itensToolStripMenuItem.Name = "itensToolStripMenuItem";
-            this.itensToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
-            this.itensToolStripMenuItem.Text = "SD card";
+            this.itensToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
+            this.itensToolStripMenuItem.Text = "SD Card";
             // 
             // itemsOnSDCardToolStripMenuItem
             // 
@@ -1283,37 +1299,22 @@
             this.itemsOnSceneReleasesToolStripMenuItem,
             this.itemsNotOnSceneReleasesToolStripMenuItem});
             this.sceneReleasesToolStripMenuItem.Name = "sceneReleasesToolStripMenuItem";
-            this.sceneReleasesToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
-            this.sceneReleasesToolStripMenuItem.Text = "Scene releases";
+            this.sceneReleasesToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
+            this.sceneReleasesToolStripMenuItem.Text = "Scene Releases";
             // 
             // itemsOnSceneReleasesToolStripMenuItem
             // 
             this.itemsOnSceneReleasesToolStripMenuItem.Name = "itemsOnSceneReleasesToolStripMenuItem";
-            this.itemsOnSceneReleasesToolStripMenuItem.Size = new System.Drawing.Size(219, 22);
-            this.itemsOnSceneReleasesToolStripMenuItem.Text = "Items on Scene releases";
+            this.itemsOnSceneReleasesToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
+            this.itemsOnSceneReleasesToolStripMenuItem.Text = "Items in Scene releases";
             this.itemsOnSceneReleasesToolStripMenuItem.Click += new System.EventHandler(this.itemsOnSceneReleasesToolStripMenuItem_Click);
             // 
             // itemsNotOnSceneReleasesToolStripMenuItem
             // 
             this.itemsNotOnSceneReleasesToolStripMenuItem.Name = "itemsNotOnSceneReleasesToolStripMenuItem";
-            this.itemsNotOnSceneReleasesToolStripMenuItem.Size = new System.Drawing.Size(219, 22);
-            this.itemsNotOnSceneReleasesToolStripMenuItem.Text = "Items not on Scene releases";
+            this.itemsNotOnSceneReleasesToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
+            this.itemsNotOnSceneReleasesToolStripMenuItem.Text = "Items not in Scene releases";
             this.itemsNotOnSceneReleasesToolStripMenuItem.Click += new System.EventHandler(this.itemsNotOnSceneReleasesToolStripMenuItem_Click);
-            // 
-            // eshopReleasesToolStripMenuItem
-            // 
-            this.eshopReleasesToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.itemsOnEshjToolStripMenuItem});
-            this.eshopReleasesToolStripMenuItem.Name = "eshopReleasesToolStripMenuItem";
-            this.eshopReleasesToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
-            this.eshopReleasesToolStripMenuItem.Text = "E-shop releases";
-            // 
-            // itemsOnEshjToolStripMenuItem
-            // 
-            this.itemsOnEshjToolStripMenuItem.Name = "itemsOnEshjToolStripMenuItem";
-            this.itemsOnEshjToolStripMenuItem.Size = new System.Drawing.Size(178, 22);
-            this.itemsOnEshjToolStripMenuItem.Text = "Items on e-shop list";
-            this.itemsOnEshjToolStripMenuItem.Click += new System.EventHandler(this.itemsOnEshjToolStripMenuItem_Click);
             // 
             // listToolStripMenuItem
             // 
@@ -1392,14 +1393,14 @@
             // selectedToolStripMenuItem
             // 
             this.selectedToolStripMenuItem.Name = "selectedToolStripMenuItem";
-            this.selectedToolStripMenuItem.Size = new System.Drawing.Size(149, 22);
+            this.selectedToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.selectedToolStripMenuItem.Text = "Selected";
             this.selectedToolStripMenuItem.Click += new System.EventHandler(this.selectedToolStripMenuItem_Click);
             // 
             // toolStripMenuItem2
             // 
             this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-            this.toolStripMenuItem2.Size = new System.Drawing.Size(146, 6);
+            this.toolStripMenuItem2.Size = new System.Drawing.Size(149, 6);
             this.toolStripMenuItem2.Visible = false;
             // 
             // sDCardToolStripMenuItem
@@ -1408,8 +1409,8 @@
             this.itemsOnSDCardToolStripMenuItem1,
             this.itemsNotOnSDCardToolStripMenuItem1});
             this.sDCardToolStripMenuItem.Name = "sDCardToolStripMenuItem";
-            this.sDCardToolStripMenuItem.Size = new System.Drawing.Size(149, 22);
-            this.sDCardToolStripMenuItem.Text = "SD card";
+            this.sDCardToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.sDCardToolStripMenuItem.Text = "SD Card";
             this.sDCardToolStripMenuItem.Visible = false;
             // 
             // itemsOnSDCardToolStripMenuItem1
@@ -1430,21 +1431,21 @@
             this.itemsOnSceneReleasesToolStripMenuItem1,
             this.itemsNotOnSceneReleasesToolStripMenuItem1});
             this.sceneReleasesToolStripMenuItem1.Name = "sceneReleasesToolStripMenuItem1";
-            this.sceneReleasesToolStripMenuItem1.Size = new System.Drawing.Size(149, 22);
-            this.sceneReleasesToolStripMenuItem1.Text = "Scene releases";
+            this.sceneReleasesToolStripMenuItem1.Size = new System.Drawing.Size(152, 22);
+            this.sceneReleasesToolStripMenuItem1.Text = "Scene Releases";
             this.sceneReleasesToolStripMenuItem1.Visible = false;
             // 
             // itemsOnSceneReleasesToolStripMenuItem1
             // 
             this.itemsOnSceneReleasesToolStripMenuItem1.Name = "itemsOnSceneReleasesToolStripMenuItem1";
-            this.itemsOnSceneReleasesToolStripMenuItem1.Size = new System.Drawing.Size(219, 22);
-            this.itemsOnSceneReleasesToolStripMenuItem1.Text = "Items on Scene releases";
+            this.itemsOnSceneReleasesToolStripMenuItem1.Size = new System.Drawing.Size(215, 22);
+            this.itemsOnSceneReleasesToolStripMenuItem1.Text = "Items in Scene releases";
             // 
             // itemsNotOnSceneReleasesToolStripMenuItem1
             // 
             this.itemsNotOnSceneReleasesToolStripMenuItem1.Name = "itemsNotOnSceneReleasesToolStripMenuItem1";
-            this.itemsNotOnSceneReleasesToolStripMenuItem1.Size = new System.Drawing.Size(219, 22);
-            this.itemsNotOnSceneReleasesToolStripMenuItem1.Text = "Items not on Scene releases";
+            this.itemsNotOnSceneReleasesToolStripMenuItem1.Size = new System.Drawing.Size(215, 22);
+            this.itemsNotOnSceneReleasesToolStripMenuItem1.Text = "Items not in Scene releases";
             // 
             // transferToolStripMenuItem
             // 
@@ -1462,7 +1463,7 @@
             this.moveFilesToolStripMenuItem});
             this.sDCardToolStripMenuItem1.Name = "sDCardToolStripMenuItem1";
             this.sDCardToolStripMenuItem1.Size = new System.Drawing.Size(116, 22);
-            this.sDCardToolStripMenuItem1.Text = "SD card";
+            this.sDCardToolStripMenuItem1.Text = "SD Card";
             // 
             // copyFilesToolStripMenuItem
             // 
@@ -1592,6 +1593,7 @@
             // 
             this.toolStripMenuItem3.Name = "toolStripMenuItem3";
             this.toolStripMenuItem3.Size = new System.Drawing.Size(155, 6);
+            this.toolStripMenuItem3.Visible = false;
             // 
             // exportGameListToolStripMenuItem
             // 
@@ -1615,22 +1617,765 @@
             this.cSVToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
             this.cSVToolStripMenuItem.Text = "CSV";
             // 
-            // tabPage2
+            // tabPageNSP
             // 
-            this.tabPage2.Controls.Add(this.btnClearFilterSD);
-            this.tabPage2.Controls.Add(this.textBoxFilterSD);
-            this.tabPage2.Controls.Add(this.label3);
-            this.tabPage2.Controls.Add(this.cbxFilterSD);
-            this.tabPage2.Controls.Add(this.OLV_SDCard);
-            this.tabPage2.Controls.Add(this.panel5);
-            this.tabPage2.Controls.Add(this.menuSDFiles);
-            this.tabPage2.Location = new System.Drawing.Point(4, 22);
-            this.tabPage2.Name = "tabPage2";
-            this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(1517, 366);
-            this.tabPage2.TabIndex = 1;
-            this.tabPage2.Text = "SD card";
-            this.tabPage2.UseVisualStyleBackColor = true;
+            this.tabPageNSP.Controls.Add(this.panel10);
+            this.tabPageNSP.Controls.Add(this.panel11);
+            this.tabPageNSP.Location = new System.Drawing.Point(4, 22);
+            this.tabPageNSP.Name = "tabPageNSP";
+            this.tabPageNSP.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPageNSP.Size = new System.Drawing.Size(1519, 368);
+            this.tabPageNSP.TabIndex = 3;
+            this.tabPageNSP.Text = "NSP Files";
+            this.tabPageNSP.UseVisualStyleBackColor = true;
+            // 
+            // panel10
+            // 
+            this.panel10.Controls.Add(this.OLVEshop);
+            this.panel10.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panel10.Location = new System.Drawing.Point(3, 31);
+            this.panel10.Name = "panel10";
+            this.panel10.Size = new System.Drawing.Size(1513, 334);
+            this.panel10.TabIndex = 11;
+            // 
+            // OLVEshop
+            // 
+            this.OLVEshop.AllColumns.Add(this.olvColumnTitleIDEShop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnGameNameEShop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnROMSizeEshop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnLanguagesEShop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnFilePathEShop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnDeveloperEShop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnPublisherEshop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnGameRevisionEShop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnVersionEShop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnLatestEShop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnMasterKeyRevisionEShop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnDistributionType);
+            this.OLVEshop.AllColumns.Add(this.olvColumnFirmwareEShop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnSDKVersionEShop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnReleaseDateEshop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnNumberOfPlayersEshop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnCategoriesEShop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnContentTypeEShop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnImportedDateEShop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnSourceEShop);
+            this.OLVEshop.CellEditUseWholeCell = false;
+            this.OLVEshop.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.olvColumnTitleIDEShop,
+            this.olvColumnGameNameEShop,
+            this.olvColumnROMSizeEshop,
+            this.olvColumnLanguagesEShop,
+            this.olvColumnFilePathEShop,
+            this.olvColumnDeveloperEShop,
+            this.olvColumnPublisherEshop,
+            this.olvColumnGameRevisionEShop,
+            this.olvColumnVersionEShop,
+            this.olvColumnLatestEShop,
+            this.olvColumnMasterKeyRevisionEShop,
+            this.olvColumnDistributionType,
+            this.olvColumnFirmwareEShop,
+            this.olvColumnSDKVersionEShop,
+            this.olvColumnReleaseDateEshop,
+            this.olvColumnNumberOfPlayersEshop,
+            this.olvColumnCategoriesEShop,
+            this.olvColumnContentTypeEShop,
+            this.olvColumnImportedDateEShop,
+            this.olvColumnSourceEShop});
+            this.OLVEshop.ContextMenuStrip = this.contextMenuEShopList;
+            this.OLVEshop.Cursor = System.Windows.Forms.Cursors.Default;
+            this.OLVEshop.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.OLVEshop.FullRowSelect = true;
+            this.OLVEshop.GridLines = true;
+            this.OLVEshop.Location = new System.Drawing.Point(0, 0);
+            this.OLVEshop.Name = "OLVEshop";
+            this.OLVEshop.ShowGroups = false;
+            this.OLVEshop.Size = new System.Drawing.Size(1513, 334);
+            this.OLVEshop.TabIndex = 3;
+            this.OLVEshop.UseCellFormatEvents = true;
+            this.OLVEshop.UseCompatibleStateImageBehavior = false;
+            this.OLVEshop.UseExplorerTheme = true;
+            this.OLVEshop.View = System.Windows.Forms.View.Details;
+            this.OLVEshop.CellOver += new System.EventHandler<BrightIdeasSoftware.CellOverEventArgs>(this.OLVEshop_CellOver);
+            this.OLVEshop.FormatCell += new System.EventHandler<BrightIdeasSoftware.FormatCellEventArgs>(this.OLVEshop_FormatCell);
+            this.OLVEshop.ItemSelectionChanged += new System.Windows.Forms.ListViewItemSelectionChangedEventHandler(this.OLVEshop_ItemSelectionChanged);
+            this.OLVEshop.KeyDown += new System.Windows.Forms.KeyEventHandler(this.OLVEshop_KeyDown);
+            // 
+            // olvColumnTitleIDEShop
+            // 
+            this.olvColumnTitleIDEShop.AspectName = "TitleID";
+            this.olvColumnTitleIDEShop.Text = "Title ID";
+            this.olvColumnTitleIDEShop.Width = 200;
+            // 
+            // olvColumnGameNameEShop
+            // 
+            this.olvColumnGameNameEShop.AspectName = "GameName";
+            this.olvColumnGameNameEShop.Text = "Game title";
+            this.olvColumnGameNameEShop.UseInitialLetterForGroup = true;
+            this.olvColumnGameNameEShop.Width = 280;
+            // 
+            // olvColumnROMSizeEshop
+            // 
+            this.olvColumnROMSizeEshop.AspectName = "ROMSizeBytes";
+            this.olvColumnROMSizeEshop.Text = "ROM size";
+            this.olvColumnROMSizeEshop.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this.olvColumnROMSizeEshop.UseInitialLetterForGroup = true;
+            this.olvColumnROMSizeEshop.Width = 65;
+            // 
+            // olvColumnLanguagesEShop
+            // 
+            this.olvColumnLanguagesEShop.AspectName = "Languages";
+            this.olvColumnLanguagesEShop.Text = "Languages";
+            this.olvColumnLanguagesEShop.Width = 100;
+            // 
+            // olvColumnFilePathEShop
+            // 
+            this.olvColumnFilePathEShop.AspectName = "FilePath";
+            this.olvColumnFilePathEShop.Text = "Filename";
+            this.olvColumnFilePathEShop.UseInitialLetterForGroup = true;
+            this.olvColumnFilePathEShop.Width = 280;
+            // 
+            // olvColumnDeveloperEShop
+            // 
+            this.olvColumnDeveloperEShop.AspectName = "Developer";
+            this.olvColumnDeveloperEShop.Text = "Developer";
+            this.olvColumnDeveloperEShop.Width = 204;
+            // 
+            // olvColumnPublisherEshop
+            // 
+            this.olvColumnPublisherEshop.AspectName = "Publisher ";
+            this.olvColumnPublisherEshop.Text = "Publisher";
+            // 
+            // olvColumnGameRevisionEShop
+            // 
+            this.olvColumnGameRevisionEShop.AspectName = "GameRevision";
+            this.olvColumnGameRevisionEShop.Text = "Game revision";
+            this.olvColumnGameRevisionEShop.UseInitialLetterForGroup = true;
+            this.olvColumnGameRevisionEShop.Width = 100;
+            // 
+            // olvColumnVersionEShop
+            // 
+            this.olvColumnVersionEShop.AspectName = "Version";
+            this.olvColumnVersionEShop.Text = "Version";
+            this.olvColumnVersionEShop.Width = 100;
+            // 
+            // olvColumnLatestEShop
+            // 
+            this.olvColumnLatestEShop.AspectName = "Latest";
+            this.olvColumnLatestEShop.Text = "Latest";
+            this.olvColumnLatestEShop.Width = 100;
+            // 
+            // olvColumnMasterKeyRevisionEShop
+            // 
+            this.olvColumnMasterKeyRevisionEShop.AspectName = "MasterKeyRevision";
+            this.olvColumnMasterKeyRevisionEShop.Text = "Masterkey revision";
+            this.olvColumnMasterKeyRevisionEShop.Width = 135;
+            // 
+            // olvColumnDistributionType
+            // 
+            this.olvColumnDistributionType.AspectName = "DistributionType";
+            this.olvColumnDistributionType.Text = "Distribution";
+            this.olvColumnDistributionType.Width = 72;
+            // 
+            // olvColumnFirmwareEShop
+            // 
+            this.olvColumnFirmwareEShop.AspectName = "Firmware";
+            this.olvColumnFirmwareEShop.Text = "Firmware";
+            this.olvColumnFirmwareEShop.Width = 100;
+            // 
+            // olvColumnSDKVersionEShop
+            // 
+            this.olvColumnSDKVersionEShop.AspectName = "SDKVersion";
+            this.olvColumnSDKVersionEShop.Text = "SDK Version";
+            this.olvColumnSDKVersionEShop.Width = 100;
+            // 
+            // olvColumnReleaseDateEshop
+            // 
+            this.olvColumnReleaseDateEshop.AspectName = "ReleaseDate ";
+            this.olvColumnReleaseDateEshop.Text = "Release date";
+            this.olvColumnReleaseDateEshop.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            // 
+            // olvColumnNumberOfPlayersEshop
+            // 
+            this.olvColumnNumberOfPlayersEshop.AspectName = "NumberOfPlayers ";
+            this.olvColumnNumberOfPlayersEshop.Text = "Nº of players";
+            this.olvColumnNumberOfPlayersEshop.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            // 
+            // olvColumnCategoriesEShop
+            // 
+            this.olvColumnCategoriesEShop.AspectName = "Categories ";
+            this.olvColumnCategoriesEShop.Text = "Category";
+            // 
+            // olvColumnContentTypeEShop
+            // 
+            this.olvColumnContentTypeEShop.AspectName = "ContentType";
+            this.olvColumnContentTypeEShop.Text = "Content Type";
+            // 
+            // olvColumnImportedDateEShop
+            // 
+            this.olvColumnImportedDateEShop.AspectName = "ImportedDate";
+            this.olvColumnImportedDateEShop.IsEditable = false;
+            this.olvColumnImportedDateEShop.Text = "Imported Date";
+            // 
+            // olvColumnSourceEShop
+            // 
+            this.olvColumnSourceEShop.AspectName = "Source";
+            this.olvColumnSourceEShop.Text = "Source";
+            this.olvColumnSourceEShop.Width = 80;
+            // 
+            // contextMenuEShopList
+            // 
+            this.contextMenuEShopList.ImageScalingSize = new System.Drawing.Size(24, 24);
+            this.contextMenuEShopList.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemEShopShowInExplorer,
+            this.toolStripMenuItemEShopUpdateInfo,
+            this.toolStripSeparator9,
+            this.toolStripMenuItemEShopAutoRename,
+            this.toolStripSeparator10,
+            this.toolStripMenuItemEShopCopyToFolder,
+            this.toolStripMenuItemEShopMoveToFolder,
+            this.toolStripMenuItem64,
+            this.copyInfoToClipboardToolStripMenuItem,
+            this.updateGameInfoFromWebToolStripMenuItemEshop,
+            this.toolStripMenuItem97Eshop,
+            this.deleteSelectedFilesToolStripMenuItemEshop});
+            this.contextMenuEShopList.Name = "contextMenuStripSDCard";
+            this.contextMenuEShopList.Size = new System.Drawing.Size(277, 204);
+            this.contextMenuEShopList.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStripEShop_Opening);
+            // 
+            // toolStripMenuItemEShopShowInExplorer
+            // 
+            this.toolStripMenuItemEShopShowInExplorer.Name = "toolStripMenuItemEShopShowInExplorer";
+            this.toolStripMenuItemEShopShowInExplorer.Size = new System.Drawing.Size(276, 22);
+            this.toolStripMenuItemEShopShowInExplorer.Text = "Show in explorer";
+            this.toolStripMenuItemEShopShowInExplorer.Click += new System.EventHandler(this.toolStripMenuItemEShopShowInExplorer_Click);
+            // 
+            // toolStripMenuItemEShopUpdateInfo
+            // 
+            this.toolStripMenuItemEShopUpdateInfo.Name = "toolStripMenuItemEShopUpdateInfo";
+            this.toolStripMenuItemEShopUpdateInfo.Size = new System.Drawing.Size(276, 22);
+            this.toolStripMenuItemEShopUpdateInfo.Text = "Update info";
+            this.toolStripMenuItemEShopUpdateInfo.Visible = false;
+            this.toolStripMenuItemEShopUpdateInfo.Click += new System.EventHandler(this.toolStripMenuItemEShopUpdateInfo_Click);
+            // 
+            // toolStripSeparator9
+            // 
+            this.toolStripSeparator9.Name = "toolStripSeparator9";
+            this.toolStripSeparator9.Size = new System.Drawing.Size(273, 6);
+            // 
+            // toolStripMenuItemEShopAutoRename
+            // 
+            this.toolStripMenuItemEShopAutoRename.Name = "toolStripMenuItemEShopAutoRename";
+            this.toolStripMenuItemEShopAutoRename.Size = new System.Drawing.Size(276, 22);
+            this.toolStripMenuItemEShopAutoRename.Text = "Auto rename files";
+            this.toolStripMenuItemEShopAutoRename.Click += new System.EventHandler(this.toolStripMenuItemEShopAutoRename_Click);
+            // 
+            // toolStripSeparator10
+            // 
+            this.toolStripSeparator10.Name = "toolStripSeparator10";
+            this.toolStripSeparator10.Size = new System.Drawing.Size(273, 6);
+            // 
+            // toolStripMenuItemEShopCopyToFolder
+            // 
+            this.toolStripMenuItemEShopCopyToFolder.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.sDCardToolStripMenuItem4,
+            this.folderToolStripMenuItem5});
+            this.toolStripMenuItemEShopCopyToFolder.Name = "toolStripMenuItemEShopCopyToFolder";
+            this.toolStripMenuItemEShopCopyToFolder.Size = new System.Drawing.Size(276, 22);
+            this.toolStripMenuItemEShopCopyToFolder.Text = "Copy files to";
+            // 
+            // sDCardToolStripMenuItem4
+            // 
+            this.sDCardToolStripMenuItem4.Name = "sDCardToolStripMenuItem4";
+            this.sDCardToolStripMenuItem4.Size = new System.Drawing.Size(116, 22);
+            this.sDCardToolStripMenuItem4.Text = "SD Card";
+            this.sDCardToolStripMenuItem4.Click += new System.EventHandler(this.sDCardToolStripMenuItem4_Click);
+            // 
+            // folderToolStripMenuItem5
+            // 
+            this.folderToolStripMenuItem5.Name = "folderToolStripMenuItem5";
+            this.folderToolStripMenuItem5.Size = new System.Drawing.Size(116, 22);
+            this.folderToolStripMenuItem5.Text = "Folder...";
+            this.folderToolStripMenuItem5.Click += new System.EventHandler(this.folderToolStripMenuItem5_Click);
+            // 
+            // toolStripMenuItemEShopMoveToFolder
+            // 
+            this.toolStripMenuItemEShopMoveToFolder.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.sDCardToolStripMenuItem5,
+            this.folderToolStripMenuItem6});
+            this.toolStripMenuItemEShopMoveToFolder.Name = "toolStripMenuItemEShopMoveToFolder";
+            this.toolStripMenuItemEShopMoveToFolder.Size = new System.Drawing.Size(276, 22);
+            this.toolStripMenuItemEShopMoveToFolder.Text = "Move files to";
+            // 
+            // sDCardToolStripMenuItem5
+            // 
+            this.sDCardToolStripMenuItem5.Name = "sDCardToolStripMenuItem5";
+            this.sDCardToolStripMenuItem5.Size = new System.Drawing.Size(116, 22);
+            this.sDCardToolStripMenuItem5.Text = "SD Card";
+            this.sDCardToolStripMenuItem5.Click += new System.EventHandler(this.sDCardToolStripMenuItem5_Click);
+            // 
+            // folderToolStripMenuItem6
+            // 
+            this.folderToolStripMenuItem6.Name = "folderToolStripMenuItem6";
+            this.folderToolStripMenuItem6.Size = new System.Drawing.Size(116, 22);
+            this.folderToolStripMenuItem6.Text = "Folder...";
+            this.folderToolStripMenuItem6.Click += new System.EventHandler(this.folderToolStripMenuItem6_Click);
+            // 
+            // toolStripMenuItem64
+            // 
+            this.toolStripMenuItem64.Name = "toolStripMenuItem64";
+            this.toolStripMenuItem64.Size = new System.Drawing.Size(273, 6);
+            // 
+            // copyInfoToClipboardToolStripMenuItem
+            // 
+            this.copyInfoToClipboardToolStripMenuItem.Name = "copyInfoToClipboardToolStripMenuItem";
+            this.copyInfoToClipboardToolStripMenuItem.Size = new System.Drawing.Size(276, 22);
+            this.copyInfoToClipboardToolStripMenuItem.Text = "Copy info to clipboard";
+            this.copyInfoToClipboardToolStripMenuItem.Click += new System.EventHandler(this.copyInfoToClipboardToolStripMenuItem_Click);
+            // 
+            // updateGameInfoFromWebToolStripMenuItemEshop
+            // 
+            this.updateGameInfoFromWebToolStripMenuItemEshop.Name = "updateGameInfoFromWebToolStripMenuItemEshop";
+            this.updateGameInfoFromWebToolStripMenuItemEshop.Size = new System.Drawing.Size(276, 22);
+            this.updateGameInfoFromWebToolStripMenuItemEshop.Text = "Update game info from Web";
+            this.updateGameInfoFromWebToolStripMenuItemEshop.Click += new System.EventHandler(this.updateGameInfoFromWebToolStripMenuItemEshop_Click);
+            // 
+            // toolStripMenuItem97Eshop
+            // 
+            this.toolStripMenuItem97Eshop.Name = "toolStripMenuItem97Eshop";
+            this.toolStripMenuItem97Eshop.Size = new System.Drawing.Size(273, 6);
+            // 
+            // deleteSelectedFilesToolStripMenuItemEshop
+            // 
+            this.deleteSelectedFilesToolStripMenuItemEshop.Name = "deleteSelectedFilesToolStripMenuItemEshop";
+            this.deleteSelectedFilesToolStripMenuItemEshop.Size = new System.Drawing.Size(276, 22);
+            this.deleteSelectedFilesToolStripMenuItemEshop.Text = "Delete selected files (erases from disk!)";
+            this.deleteSelectedFilesToolStripMenuItemEshop.Click += new System.EventHandler(this.deleteSelectedFilesToolStripMenuItemEshop_Click);
+            // 
+            // panel11
+            // 
+            this.panel11.Controls.Add(this.panel13);
+            this.panel11.Controls.Add(this.panel12);
+            this.panel11.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panel11.Location = new System.Drawing.Point(3, 3);
+            this.panel11.Name = "panel11";
+            this.panel11.Size = new System.Drawing.Size(1513, 28);
+            this.panel11.TabIndex = 10;
+            // 
+            // panel13
+            // 
+            this.panel13.Controls.Add(this.cbBaseGame);
+            this.panel13.Controls.Add(this.cbUpdates);
+            this.panel13.Controls.Add(this.cbDLC);
+            this.panel13.Controls.Add(this.btnClearFilterEShop);
+            this.panel13.Controls.Add(this.textBoxFilterEShop);
+            this.panel13.Controls.Add(this.label5);
+            this.panel13.Controls.Add(this.cbxFilterEshop);
+            this.panel13.Dock = System.Windows.Forms.DockStyle.Right;
+            this.panel13.Location = new System.Drawing.Point(800, 0);
+            this.panel13.Name = "panel13";
+            this.panel13.Size = new System.Drawing.Size(713, 28);
+            this.panel13.TabIndex = 1;
+            // 
+            // cbBaseGame
+            // 
+            this.cbBaseGame.AutoSize = true;
+            this.cbBaseGame.Checked = true;
+            this.cbBaseGame.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cbBaseGame.Location = new System.Drawing.Point(126, 5);
+            this.cbBaseGame.Name = "cbBaseGame";
+            this.cbBaseGame.Size = new System.Drawing.Size(79, 17);
+            this.cbBaseGame.TabIndex = 20;
+            this.cbBaseGame.Text = "Base game";
+            this.cbBaseGame.UseVisualStyleBackColor = true;
+            this.cbBaseGame.CheckedChanged += new System.EventHandler(this.cbBaseGame_CheckedChanged);
+            // 
+            // cbUpdates
+            // 
+            this.cbUpdates.AutoSize = true;
+            this.cbUpdates.Checked = true;
+            this.cbUpdates.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cbUpdates.Location = new System.Drawing.Point(58, 5);
+            this.cbUpdates.Name = "cbUpdates";
+            this.cbUpdates.Size = new System.Drawing.Size(61, 17);
+            this.cbUpdates.TabIndex = 19;
+            this.cbUpdates.Text = "Update";
+            this.cbUpdates.UseVisualStyleBackColor = true;
+            this.cbUpdates.CheckedChanged += new System.EventHandler(this.cbUpdates_CheckedChanged);
+            // 
+            // cbDLC
+            // 
+            this.cbDLC.AutoSize = true;
+            this.cbDLC.Location = new System.Drawing.Point(4, 5);
+            this.cbDLC.Name = "cbDLC";
+            this.cbDLC.Size = new System.Drawing.Size(47, 17);
+            this.cbDLC.TabIndex = 18;
+            this.cbDLC.Text = "DLC";
+            this.cbDLC.UseVisualStyleBackColor = true;
+            this.cbDLC.CheckedChanged += new System.EventHandler(this.cbDLC_CheckedChanged);
+            // 
+            // btnClearFilterEShop
+            // 
+            this.btnClearFilterEShop.Location = new System.Drawing.Point(634, 2);
+            this.btnClearFilterEShop.Name = "btnClearFilterEShop";
+            this.btnClearFilterEShop.Size = new System.Drawing.Size(75, 23);
+            this.btnClearFilterEShop.TabIndex = 17;
+            this.btnClearFilterEShop.Text = "Clear";
+            this.btnClearFilterEShop.UseVisualStyleBackColor = true;
+            this.btnClearFilterEShop.Click += new System.EventHandler(this.btnClearFilterEShop_Click);
+            // 
+            // textBoxFilterEShop
+            // 
+            this.textBoxFilterEShop.Location = new System.Drawing.Point(359, 4);
+            this.textBoxFilterEShop.Name = "textBoxFilterEShop";
+            this.textBoxFilterEShop.Size = new System.Drawing.Size(268, 20);
+            this.textBoxFilterEShop.TabIndex = 16;
+            this.textBoxFilterEShop.TextChanged += new System.EventHandler(this.textBoxFilterEShop_TextChanged);
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.BackColor = System.Drawing.SystemColors.Window;
+            this.label5.Location = new System.Drawing.Point(215, 7);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(32, 13);
+            this.label5.TabIndex = 15;
+            this.label5.Text = "Filter:";
+            // 
+            // cbxFilterEshop
+            // 
+            this.cbxFilterEshop.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbxFilterEshop.FormattingEnabled = true;
+            this.cbxFilterEshop.Location = new System.Drawing.Point(250, 3);
+            this.cbxFilterEshop.Name = "cbxFilterEshop";
+            this.cbxFilterEshop.Size = new System.Drawing.Size(102, 21);
+            this.cbxFilterEshop.TabIndex = 14;
+            this.cbxFilterEshop.SelectedIndexChanged += new System.EventHandler(this.cbxFilterEshop_SelectedIndexChanged);
+            // 
+            // panel12
+            // 
+            this.panel12.Controls.Add(this.menuEShop);
+            this.panel12.Dock = System.Windows.Forms.DockStyle.Left;
+            this.panel12.Location = new System.Drawing.Point(0, 0);
+            this.panel12.Name = "panel12";
+            this.panel12.Size = new System.Drawing.Size(777, 28);
+            this.panel12.TabIndex = 0;
+            // 
+            // menuEShop
+            // 
+            this.menuEShop.ImageScalingSize = new System.Drawing.Size(24, 24);
+            this.menuEShop.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.addToolStripMenuItemAddFolderEShop,
+            this.toolStripMenuItemSelectEshop,
+            this.toolStripMenuItem22,
+            this.toolStripMenuItem23,
+            this.toolStripMenuItem24});
+            this.menuEShop.Location = new System.Drawing.Point(0, 0);
+            this.menuEShop.Name = "menuEShop";
+            this.menuEShop.Size = new System.Drawing.Size(777, 24);
+            this.menuEShop.TabIndex = 9;
+            this.menuEShop.Text = "menuStrip2";
+            // 
+            // addToolStripMenuItemAddFolderEShop
+            // 
+            this.addToolStripMenuItemAddFolderEShop.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.filesToolStripMenuItem1,
+            this.folderToolStripMenuItem4});
+            this.addToolStripMenuItemAddFolderEShop.Name = "addToolStripMenuItemAddFolderEShop";
+            this.addToolStripMenuItemAddFolderEShop.Size = new System.Drawing.Size(41, 20);
+            this.addToolStripMenuItemAddFolderEShop.Text = "Add";
+            // 
+            // filesToolStripMenuItem1
+            // 
+            this.filesToolStripMenuItem1.Name = "filesToolStripMenuItem1";
+            this.filesToolStripMenuItem1.Size = new System.Drawing.Size(116, 22);
+            this.filesToolStripMenuItem1.Text = "Files...";
+            this.filesToolStripMenuItem1.Click += new System.EventHandler(this.filesToolStripMenuItem1_Click);
+            // 
+            // folderToolStripMenuItem4
+            // 
+            this.folderToolStripMenuItem4.Name = "folderToolStripMenuItem4";
+            this.folderToolStripMenuItem4.Size = new System.Drawing.Size(116, 22);
+            this.folderToolStripMenuItem4.Text = "Folder...";
+            this.folderToolStripMenuItem4.Click += new System.EventHandler(this.folderToolStripMenuItem4_Click);
+            // 
+            // toolStripMenuItemSelectEshop
+            // 
+            this.toolStripMenuItemSelectEshop.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemSelectAllEshop,
+            this.toolStripMenuItemSelectNoneEShop,
+            this.toolStripMenuItemSelectInvertEShop,
+            this.toolStripSeparator7,
+            this.toolStripMenuItemSelectSDCardEShop,
+            this.toolStripMenuItemSelectSceneEShop,
+            this.toolStripMenuItem97,
+            this.outdatedToolStripMenuItem});
+            this.toolStripMenuItemSelectEshop.Name = "toolStripMenuItemSelectEshop";
+            this.toolStripMenuItemSelectEshop.Size = new System.Drawing.Size(50, 20);
+            this.toolStripMenuItemSelectEshop.Text = "&Select";
+            // 
+            // toolStripMenuItemSelectAllEshop
+            // 
+            this.toolStripMenuItemSelectAllEshop.Name = "toolStripMenuItemSelectAllEshop";
+            this.toolStripMenuItemSelectAllEshop.Size = new System.Drawing.Size(169, 22);
+            this.toolStripMenuItemSelectAllEshop.Text = "All";
+            this.toolStripMenuItemSelectAllEshop.Click += new System.EventHandler(this.toolStripMenuItemSelectAllEshop_Click);
+            // 
+            // toolStripMenuItemSelectNoneEShop
+            // 
+            this.toolStripMenuItemSelectNoneEShop.Name = "toolStripMenuItemSelectNoneEShop";
+            this.toolStripMenuItemSelectNoneEShop.Size = new System.Drawing.Size(169, 22);
+            this.toolStripMenuItemSelectNoneEShop.Text = "None";
+            this.toolStripMenuItemSelectNoneEShop.Click += new System.EventHandler(this.toolStripMenuItemSelectNoneEShop_Click);
+            // 
+            // toolStripMenuItemSelectInvertEShop
+            // 
+            this.toolStripMenuItemSelectInvertEShop.Name = "toolStripMenuItemSelectInvertEShop";
+            this.toolStripMenuItemSelectInvertEShop.Size = new System.Drawing.Size(169, 22);
+            this.toolStripMenuItemSelectInvertEShop.Text = "Invert selection";
+            this.toolStripMenuItemSelectInvertEShop.Click += new System.EventHandler(this.toolStripMenuItemSelectInvertEShop_Click);
+            // 
+            // toolStripSeparator7
+            // 
+            this.toolStripSeparator7.Name = "toolStripSeparator7";
+            this.toolStripSeparator7.Size = new System.Drawing.Size(166, 6);
+            // 
+            // toolStripMenuItemSelectSDCardEShop
+            // 
+            this.toolStripMenuItemSelectSDCardEShop.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemSelectSDCardItemsOnSDEShop,
+            this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop});
+            this.toolStripMenuItemSelectSDCardEShop.Name = "toolStripMenuItemSelectSDCardEShop";
+            this.toolStripMenuItemSelectSDCardEShop.Size = new System.Drawing.Size(169, 22);
+            this.toolStripMenuItemSelectSDCardEShop.Text = "SD Card";
+            // 
+            // toolStripMenuItemSelectSDCardItemsOnSDEShop
+            // 
+            this.toolStripMenuItemSelectSDCardItemsOnSDEShop.Name = "toolStripMenuItemSelectSDCardItemsOnSDEShop";
+            this.toolStripMenuItemSelectSDCardItemsOnSDEShop.Size = new System.Drawing.Size(184, 22);
+            this.toolStripMenuItemSelectSDCardItemsOnSDEShop.Text = "Items on SD card";
+            this.toolStripMenuItemSelectSDCardItemsOnSDEShop.Click += new System.EventHandler(this.toolStripMenuItemSelectSDCardItemsOnSDEShop_Click);
+            // 
+            // toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop
+            // 
+            this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop.Name = "toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop";
+            this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop.Size = new System.Drawing.Size(184, 22);
+            this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop.Text = "Items not on SD card";
+            this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop.Click += new System.EventHandler(this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop_Click);
+            // 
+            // toolStripMenuItemSelectSceneEShop
+            // 
+            this.toolStripMenuItemSelectSceneEShop.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemSelectSceneOnEShop,
+            this.toolStripMenuItemSelectSceneNotOnEShop});
+            this.toolStripMenuItemSelectSceneEShop.Name = "toolStripMenuItemSelectSceneEShop";
+            this.toolStripMenuItemSelectSceneEShop.Size = new System.Drawing.Size(169, 22);
+            this.toolStripMenuItemSelectSceneEShop.Text = "Scene Releases";
+            this.toolStripMenuItemSelectSceneEShop.Visible = false;
+            // 
+            // toolStripMenuItemSelectSceneOnEShop
+            // 
+            this.toolStripMenuItemSelectSceneOnEShop.Name = "toolStripMenuItemSelectSceneOnEShop";
+            this.toolStripMenuItemSelectSceneOnEShop.Size = new System.Drawing.Size(215, 22);
+            this.toolStripMenuItemSelectSceneOnEShop.Text = "Items in Scene releases";
+            this.toolStripMenuItemSelectSceneOnEShop.Click += new System.EventHandler(this.toolStripMenuItemSelectSceneOnEShop_Click);
+            // 
+            // toolStripMenuItemSelectSceneNotOnEShop
+            // 
+            this.toolStripMenuItemSelectSceneNotOnEShop.Name = "toolStripMenuItemSelectSceneNotOnEShop";
+            this.toolStripMenuItemSelectSceneNotOnEShop.Size = new System.Drawing.Size(215, 22);
+            this.toolStripMenuItemSelectSceneNotOnEShop.Text = "Items not in Scene releases";
+            // 
+            // toolStripMenuItem97
+            // 
+            this.toolStripMenuItem97.Name = "toolStripMenuItem97";
+            this.toolStripMenuItem97.Size = new System.Drawing.Size(166, 6);
+            // 
+            // outdatedToolStripMenuItem
+            // 
+            this.outdatedToolStripMenuItem.Name = "outdatedToolStripMenuItem";
+            this.outdatedToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.outdatedToolStripMenuItem.Text = "Outdated updates";
+            this.outdatedToolStripMenuItem.Click += new System.EventHandler(this.outdatedToolStripMenuItem_Click);
+            // 
+            // toolStripMenuItem22
+            // 
+            this.toolStripMenuItem22.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemGroupingNoneEShop,
+            this.toolStripMenuItemGroupingGameTitleEShop,
+            this.toolStripMenuItemGroupingDeveloperEShop,
+            this.toolStripMenuItemGroupingMasterKeyEShop});
+            this.toolStripMenuItem22.Name = "toolStripMenuItem22";
+            this.toolStripMenuItem22.Size = new System.Drawing.Size(69, 20);
+            this.toolStripMenuItem22.Text = "&Grouping";
+            // 
+            // toolStripMenuItemGroupingNoneEShop
+            // 
+            this.toolStripMenuItemGroupingNoneEShop.Name = "toolStripMenuItemGroupingNoneEShop";
+            this.toolStripMenuItemGroupingNoneEShop.Size = new System.Drawing.Size(172, 22);
+            this.toolStripMenuItemGroupingNoneEShop.Text = "None";
+            this.toolStripMenuItemGroupingNoneEShop.Click += new System.EventHandler(this.toolStripMenuItemGroupingNoneEShop_Click);
+            // 
+            // toolStripMenuItemGroupingGameTitleEShop
+            // 
+            this.toolStripMenuItemGroupingGameTitleEShop.Name = "toolStripMenuItemGroupingGameTitleEShop";
+            this.toolStripMenuItemGroupingGameTitleEShop.Size = new System.Drawing.Size(172, 22);
+            this.toolStripMenuItemGroupingGameTitleEShop.Text = "Game title";
+            this.toolStripMenuItemGroupingGameTitleEShop.Click += new System.EventHandler(this.toolStripMenuItemGroupingGameTitleEShop_Click);
+            // 
+            // toolStripMenuItemGroupingDeveloperEShop
+            // 
+            this.toolStripMenuItemGroupingDeveloperEShop.Name = "toolStripMenuItemGroupingDeveloperEShop";
+            this.toolStripMenuItemGroupingDeveloperEShop.Size = new System.Drawing.Size(172, 22);
+            this.toolStripMenuItemGroupingDeveloperEShop.Text = "Developer";
+            this.toolStripMenuItemGroupingDeveloperEShop.Click += new System.EventHandler(this.toolStripMenuItemGroupingDeveloperEShop_Click);
+            // 
+            // toolStripMenuItemGroupingMasterKeyEShop
+            // 
+            this.toolStripMenuItemGroupingMasterKeyEShop.Name = "toolStripMenuItemGroupingMasterKeyEShop";
+            this.toolStripMenuItemGroupingMasterKeyEShop.Size = new System.Drawing.Size(172, 22);
+            this.toolStripMenuItemGroupingMasterKeyEShop.Text = "Masterkey revision";
+            this.toolStripMenuItemGroupingMasterKeyEShop.Click += new System.EventHandler(this.toolStripMenuItemGroupingMasterKeyEShop_Click);
+            // 
+            // toolStripMenuItem23
+            // 
+            this.toolStripMenuItem23.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemRemoveSelectedEShop,
+            this.toolStripSeparator8,
+            this.toolStripMenuItem44,
+            this.toolStripMenuItem65});
+            this.toolStripMenuItem23.Name = "toolStripMenuItem23";
+            this.toolStripMenuItem23.Size = new System.Drawing.Size(117, 20);
+            this.toolStripMenuItem23.Text = "&Remove (from list)";
+            // 
+            // toolStripMenuItemRemoveSelectedEShop
+            // 
+            this.toolStripMenuItemRemoveSelectedEShop.Name = "toolStripMenuItemRemoveSelectedEShop";
+            this.toolStripMenuItemRemoveSelectedEShop.Size = new System.Drawing.Size(152, 22);
+            this.toolStripMenuItemRemoveSelectedEShop.Text = "Selected";
+            this.toolStripMenuItemRemoveSelectedEShop.Click += new System.EventHandler(this.toolStripMenuItemRemoveSelectedEShop_Click);
+            // 
+            // toolStripSeparator8
+            // 
+            this.toolStripSeparator8.Name = "toolStripSeparator8";
+            this.toolStripSeparator8.Size = new System.Drawing.Size(149, 6);
+            this.toolStripSeparator8.Visible = false;
+            // 
+            // toolStripMenuItem44
+            // 
+            this.toolStripMenuItem44.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemRemoveFilesOnSDCardEShop,
+            this.toolStripMenuItemRemoveFilesNotOnSDCardEShop});
+            this.toolStripMenuItem44.Name = "toolStripMenuItem44";
+            this.toolStripMenuItem44.Size = new System.Drawing.Size(152, 22);
+            this.toolStripMenuItem44.Text = "SD Card";
+            this.toolStripMenuItem44.Visible = false;
+            // 
+            // toolStripMenuItemRemoveFilesOnSDCardEShop
+            // 
+            this.toolStripMenuItemRemoveFilesOnSDCardEShop.Name = "toolStripMenuItemRemoveFilesOnSDCardEShop";
+            this.toolStripMenuItemRemoveFilesOnSDCardEShop.Size = new System.Drawing.Size(184, 22);
+            this.toolStripMenuItemRemoveFilesOnSDCardEShop.Text = "Items on SD card";
+            // 
+            // toolStripMenuItemRemoveFilesNotOnSDCardEShop
+            // 
+            this.toolStripMenuItemRemoveFilesNotOnSDCardEShop.Name = "toolStripMenuItemRemoveFilesNotOnSDCardEShop";
+            this.toolStripMenuItemRemoveFilesNotOnSDCardEShop.Size = new System.Drawing.Size(184, 22);
+            this.toolStripMenuItemRemoveFilesNotOnSDCardEShop.Text = "Items not on SD card";
+            // 
+            // toolStripMenuItem65
+            // 
+            this.toolStripMenuItem65.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItem66,
+            this.toolStripMenuItem67});
+            this.toolStripMenuItem65.Name = "toolStripMenuItem65";
+            this.toolStripMenuItem65.Size = new System.Drawing.Size(152, 22);
+            this.toolStripMenuItem65.Text = "Scene Releases";
+            this.toolStripMenuItem65.Visible = false;
+            // 
+            // toolStripMenuItem66
+            // 
+            this.toolStripMenuItem66.Name = "toolStripMenuItem66";
+            this.toolStripMenuItem66.Size = new System.Drawing.Size(215, 22);
+            this.toolStripMenuItem66.Text = "Items in Scene releases";
+            // 
+            // toolStripMenuItem67
+            // 
+            this.toolStripMenuItem67.Name = "toolStripMenuItem67";
+            this.toolStripMenuItem67.Size = new System.Drawing.Size(215, 22);
+            this.toolStripMenuItem67.Text = "Items not in Scene releases";
+            // 
+            // toolStripMenuItem24
+            // 
+            this.toolStripMenuItem24.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItem45,
+            this.toolStripMenuItem69});
+            this.toolStripMenuItem24.Name = "toolStripMenuItem24";
+            this.toolStripMenuItem24.Size = new System.Drawing.Size(75, 20);
+            this.toolStripMenuItem24.Text = "&Transfer to";
+            // 
+            // toolStripMenuItem45
+            // 
+            this.toolStripMenuItem45.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemCopyFilesToSDEShop,
+            this.toolStripMenuItemMoveFilesToSDEShop});
+            this.toolStripMenuItem45.Name = "toolStripMenuItem45";
+            this.toolStripMenuItem45.Size = new System.Drawing.Size(116, 22);
+            this.toolStripMenuItem45.Text = "SD Card";
+            // 
+            // toolStripMenuItemCopyFilesToSDEShop
+            // 
+            this.toolStripMenuItemCopyFilesToSDEShop.Name = "toolStripMenuItemCopyFilesToSDEShop";
+            this.toolStripMenuItemCopyFilesToSDEShop.Size = new System.Drawing.Size(128, 22);
+            this.toolStripMenuItemCopyFilesToSDEShop.Text = "Copy files";
+            this.toolStripMenuItemCopyFilesToSDEShop.Click += new System.EventHandler(this.toolStripMenuItemCopyFilesToSDEShop_Click);
+            // 
+            // toolStripMenuItemMoveFilesToSDEShop
+            // 
+            this.toolStripMenuItemMoveFilesToSDEShop.Name = "toolStripMenuItemMoveFilesToSDEShop";
+            this.toolStripMenuItemMoveFilesToSDEShop.Size = new System.Drawing.Size(128, 22);
+            this.toolStripMenuItemMoveFilesToSDEShop.Text = "Move files";
+            this.toolStripMenuItemMoveFilesToSDEShop.Click += new System.EventHandler(this.toolStripMenuItemMoveFilesToSDEShop_Click);
+            // 
+            // toolStripMenuItem69
+            // 
+            this.toolStripMenuItem69.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemCopyFilesToFolderEShop,
+            this.toolStripMenuItemMoveFilesToFolderEShop});
+            this.toolStripMenuItem69.Name = "toolStripMenuItem69";
+            this.toolStripMenuItem69.Size = new System.Drawing.Size(116, 22);
+            this.toolStripMenuItem69.Text = "Folder...";
+            // 
+            // toolStripMenuItemCopyFilesToFolderEShop
+            // 
+            this.toolStripMenuItemCopyFilesToFolderEShop.Name = "toolStripMenuItemCopyFilesToFolderEShop";
+            this.toolStripMenuItemCopyFilesToFolderEShop.Size = new System.Drawing.Size(128, 22);
+            this.toolStripMenuItemCopyFilesToFolderEShop.Text = "Copy files";
+            this.toolStripMenuItemCopyFilesToFolderEShop.Click += new System.EventHandler(this.toolStripMenuItemCopyFilesToFolderEShop_Click);
+            // 
+            // toolStripMenuItemMoveFilesToFolderEShop
+            // 
+            this.toolStripMenuItemMoveFilesToFolderEShop.Name = "toolStripMenuItemMoveFilesToFolderEShop";
+            this.toolStripMenuItemMoveFilesToFolderEShop.Size = new System.Drawing.Size(128, 22);
+            this.toolStripMenuItemMoveFilesToFolderEShop.Text = "Move files";
+            this.toolStripMenuItemMoveFilesToFolderEShop.Click += new System.EventHandler(this.toolStripMenuItemMoveFilesToFolderEShop_Click);
+            // 
+            // tabPageSD
+            // 
+            this.tabPageSD.Controls.Add(this.btnClearFilterSD);
+            this.tabPageSD.Controls.Add(this.textBoxFilterSD);
+            this.tabPageSD.Controls.Add(this.label3);
+            this.tabPageSD.Controls.Add(this.cbxFilterSD);
+            this.tabPageSD.Controls.Add(this.OLV_SDCard);
+            this.tabPageSD.Controls.Add(this.panel5);
+            this.tabPageSD.Controls.Add(this.menuSDFiles);
+            this.tabPageSD.Location = new System.Drawing.Point(4, 22);
+            this.tabPageSD.Name = "tabPageSD";
+            this.tabPageSD.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPageSD.Size = new System.Drawing.Size(1517, 366);
+            this.tabPageSD.TabIndex = 1;
+            this.tabPageSD.Text = "SD Card";
+            this.tabPageSD.UseVisualStyleBackColor = true;
             // 
             // btnClearFilterSD
             // 
@@ -2049,20 +2794,20 @@
             this.toolStripMenuItem13});
             this.toolStripMenuItem11.Name = "toolStripMenuItem11";
             this.toolStripMenuItem11.Size = new System.Drawing.Size(154, 22);
-            this.toolStripMenuItem11.Text = "Local files";
+            this.toolStripMenuItem11.Text = "XCI Files";
             // 
             // toolStripMenuItem12
             // 
             this.toolStripMenuItem12.Name = "toolStripMenuItem12";
-            this.toolStripMenuItem12.Size = new System.Drawing.Size(190, 22);
-            this.toolStripMenuItem12.Text = "Items on local files";
+            this.toolStripMenuItem12.Size = new System.Drawing.Size(176, 22);
+            this.toolStripMenuItem12.Text = "Items in XCI list";
             this.toolStripMenuItem12.Click += new System.EventHandler(this.toolStripMenuItem12_Click);
             // 
             // toolStripMenuItem13
             // 
             this.toolStripMenuItem13.Name = "toolStripMenuItem13";
-            this.toolStripMenuItem13.Size = new System.Drawing.Size(190, 22);
-            this.toolStripMenuItem13.Text = "Items not on localfiles";
+            this.toolStripMenuItem13.Size = new System.Drawing.Size(176, 22);
+            this.toolStripMenuItem13.Text = "Items not in XCI list";
             this.toolStripMenuItem13.Click += new System.EventHandler(this.toolStripMenuItem13_Click);
             // 
             // toolStripMenuItem14
@@ -2072,20 +2817,20 @@
             this.toolStripMenuItem16});
             this.toolStripMenuItem14.Name = "toolStripMenuItem14";
             this.toolStripMenuItem14.Size = new System.Drawing.Size(154, 22);
-            this.toolStripMenuItem14.Text = "Scene releases";
+            this.toolStripMenuItem14.Text = "Scene Releases";
             // 
             // toolStripMenuItem15
             // 
             this.toolStripMenuItem15.Name = "toolStripMenuItem15";
-            this.toolStripMenuItem15.Size = new System.Drawing.Size(219, 22);
-            this.toolStripMenuItem15.Text = "Items on Scene releases";
+            this.toolStripMenuItem15.Size = new System.Drawing.Size(215, 22);
+            this.toolStripMenuItem15.Text = "Items in Scene releases";
             this.toolStripMenuItem15.Click += new System.EventHandler(this.toolStripMenuItem15_Click);
             // 
             // toolStripMenuItem16
             // 
             this.toolStripMenuItem16.Name = "toolStripMenuItem16";
-            this.toolStripMenuItem16.Size = new System.Drawing.Size(219, 22);
-            this.toolStripMenuItem16.Text = "Items not on Scene releases";
+            this.toolStripMenuItem16.Size = new System.Drawing.Size(215, 22);
+            this.toolStripMenuItem16.Text = "Items not in Scene releases";
             this.toolStripMenuItem16.Click += new System.EventHandler(this.toolStripMenuItem16_Click);
             // 
             // toolStripMenuItem17
@@ -2166,13 +2911,13 @@
             // toolStripMenuItem26
             // 
             this.toolStripMenuItem26.Name = "toolStripMenuItem26";
-            this.toolStripMenuItem26.Size = new System.Drawing.Size(149, 22);
+            this.toolStripMenuItem26.Size = new System.Drawing.Size(152, 22);
             this.toolStripMenuItem26.Text = "Selected";
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(146, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(149, 6);
             // 
             // toolStripMenuItem27
             // 
@@ -2180,8 +2925,8 @@
             this.toolStripMenuItem28,
             this.toolStripMenuItem29});
             this.toolStripMenuItem27.Name = "toolStripMenuItem27";
-            this.toolStripMenuItem27.Size = new System.Drawing.Size(149, 22);
-            this.toolStripMenuItem27.Text = "SD card";
+            this.toolStripMenuItem27.Size = new System.Drawing.Size(152, 22);
+            this.toolStripMenuItem27.Text = "SD Card";
             // 
             // toolStripMenuItem28
             // 
@@ -2201,20 +2946,20 @@
             this.toolStripMenuItem31,
             this.toolStripMenuItem32});
             this.toolStripMenuItem30.Name = "toolStripMenuItem30";
-            this.toolStripMenuItem30.Size = new System.Drawing.Size(149, 22);
-            this.toolStripMenuItem30.Text = "Scene releases";
+            this.toolStripMenuItem30.Size = new System.Drawing.Size(152, 22);
+            this.toolStripMenuItem30.Text = "Scene Releases";
             // 
             // toolStripMenuItem31
             // 
             this.toolStripMenuItem31.Name = "toolStripMenuItem31";
-            this.toolStripMenuItem31.Size = new System.Drawing.Size(219, 22);
-            this.toolStripMenuItem31.Text = "Items on Scene releases";
+            this.toolStripMenuItem31.Size = new System.Drawing.Size(215, 22);
+            this.toolStripMenuItem31.Text = "Items in Scene releases";
             // 
             // toolStripMenuItem32
             // 
             this.toolStripMenuItem32.Name = "toolStripMenuItem32";
-            this.toolStripMenuItem32.Size = new System.Drawing.Size(219, 22);
-            this.toolStripMenuItem32.Text = "Items not on Scene releases";
+            this.toolStripMenuItem32.Size = new System.Drawing.Size(215, 22);
+            this.toolStripMenuItem32.Text = "Items not in Scene releases";
             // 
             // toolStripMenuItem33
             // 
@@ -2228,8 +2973,8 @@
             // toolStripMenuItem34
             // 
             this.toolStripMenuItem34.Name = "toolStripMenuItem34";
-            this.toolStripMenuItem34.Size = new System.Drawing.Size(114, 22);
-            this.toolStripMenuItem34.Text = "SD card";
+            this.toolStripMenuItem34.Size = new System.Drawing.Size(116, 22);
+            this.toolStripMenuItem34.Text = "SD Card";
             this.toolStripMenuItem34.Visible = false;
             // 
             // toolStripMenuItem35
@@ -2238,7 +2983,7 @@
             this.copyToolStripMenuItem,
             this.moveToolStripMenuItem});
             this.toolStripMenuItem35.Name = "toolStripMenuItem35";
-            this.toolStripMenuItem35.Size = new System.Drawing.Size(114, 22);
+            this.toolStripMenuItem35.Size = new System.Drawing.Size(116, 22);
             this.toolStripMenuItem35.Text = "Folder";
             // 
             // copyToolStripMenuItem
@@ -2370,16 +3115,16 @@
             this.toolStripMenuItem49.Text = "CSV";
             this.toolStripMenuItem49.Click += new System.EventHandler(this.toolStripMenuItem49_Click);
             // 
-            // tabPage3
+            // tabPageScene
             // 
-            this.tabPage3.Controls.Add(this.panel4);
-            this.tabPage3.Location = new System.Drawing.Point(4, 22);
-            this.tabPage3.Name = "tabPage3";
-            this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage3.Size = new System.Drawing.Size(1517, 366);
-            this.tabPage3.TabIndex = 2;
-            this.tabPage3.Text = "Scene releases";
-            this.tabPage3.UseVisualStyleBackColor = true;
+            this.tabPageScene.Controls.Add(this.panel4);
+            this.tabPageScene.Location = new System.Drawing.Point(4, 22);
+            this.tabPageScene.Name = "tabPageScene";
+            this.tabPageScene.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPageScene.Size = new System.Drawing.Size(1517, 366);
+            this.tabPageScene.TabIndex = 2;
+            this.tabPageScene.Text = "Scene Releases";
+            this.tabPageScene.UseVisualStyleBackColor = true;
             // 
             // panel4
             // 
@@ -2642,20 +3387,20 @@
             this.toolStripMenuItem59});
             this.toolStripMenuItem57.Name = "toolStripMenuItem57";
             this.toolStripMenuItem57.Size = new System.Drawing.Size(154, 22);
-            this.toolStripMenuItem57.Text = "Local files";
+            this.toolStripMenuItem57.Text = "XCI Files";
             // 
             // toolStripMenuItem58
             // 
             this.toolStripMenuItem58.Name = "toolStripMenuItem58";
-            this.toolStripMenuItem58.Size = new System.Drawing.Size(190, 22);
-            this.toolStripMenuItem58.Text = "Items on local files";
+            this.toolStripMenuItem58.Size = new System.Drawing.Size(176, 22);
+            this.toolStripMenuItem58.Text = "Items in XCI list";
             this.toolStripMenuItem58.Click += new System.EventHandler(this.toolStripMenuItem58_Click);
             // 
             // toolStripMenuItem59
             // 
             this.toolStripMenuItem59.Name = "toolStripMenuItem59";
-            this.toolStripMenuItem59.Size = new System.Drawing.Size(190, 22);
-            this.toolStripMenuItem59.Text = "Items not on localfiles";
+            this.toolStripMenuItem59.Size = new System.Drawing.Size(176, 22);
+            this.toolStripMenuItem59.Text = "Items not in XCI list";
             this.toolStripMenuItem59.Click += new System.EventHandler(this.toolStripMenuItem59_Click);
             // 
             // toolStripMenuItem60
@@ -2665,7 +3410,7 @@
             this.toolStripMenuItem62});
             this.toolStripMenuItem60.Name = "toolStripMenuItem60";
             this.toolStripMenuItem60.Size = new System.Drawing.Size(154, 22);
-            this.toolStripMenuItem60.Text = "SD card";
+            this.toolStripMenuItem60.Text = "SD Card";
             // 
             // toolStripMenuItem61
             // 
@@ -2789,13 +3534,13 @@
             // toolStripMenuItem72
             // 
             this.toolStripMenuItem72.Name = "toolStripMenuItem72";
-            this.toolStripMenuItem72.Size = new System.Drawing.Size(149, 22);
+            this.toolStripMenuItem72.Size = new System.Drawing.Size(152, 22);
             this.toolStripMenuItem72.Text = "Selected";
             // 
             // toolStripSeparator5
             // 
             this.toolStripSeparator5.Name = "toolStripSeparator5";
-            this.toolStripSeparator5.Size = new System.Drawing.Size(146, 6);
+            this.toolStripSeparator5.Size = new System.Drawing.Size(149, 6);
             // 
             // toolStripMenuItem73
             // 
@@ -2803,8 +3548,8 @@
             this.toolStripMenuItem74,
             this.toolStripMenuItem75});
             this.toolStripMenuItem73.Name = "toolStripMenuItem73";
-            this.toolStripMenuItem73.Size = new System.Drawing.Size(149, 22);
-            this.toolStripMenuItem73.Text = "SD card";
+            this.toolStripMenuItem73.Size = new System.Drawing.Size(152, 22);
+            this.toolStripMenuItem73.Text = "SD Card";
             // 
             // toolStripMenuItem74
             // 
@@ -2824,20 +3569,20 @@
             this.toolStripMenuItem77,
             this.toolStripMenuItem78});
             this.toolStripMenuItem76.Name = "toolStripMenuItem76";
-            this.toolStripMenuItem76.Size = new System.Drawing.Size(149, 22);
-            this.toolStripMenuItem76.Text = "Scene releases";
+            this.toolStripMenuItem76.Size = new System.Drawing.Size(152, 22);
+            this.toolStripMenuItem76.Text = "Scene Releases";
             // 
             // toolStripMenuItem77
             // 
             this.toolStripMenuItem77.Name = "toolStripMenuItem77";
-            this.toolStripMenuItem77.Size = new System.Drawing.Size(219, 22);
-            this.toolStripMenuItem77.Text = "Items on Scene releases";
+            this.toolStripMenuItem77.Size = new System.Drawing.Size(215, 22);
+            this.toolStripMenuItem77.Text = "Items in Scene releases";
             // 
             // toolStripMenuItem78
             // 
             this.toolStripMenuItem78.Name = "toolStripMenuItem78";
-            this.toolStripMenuItem78.Size = new System.Drawing.Size(219, 22);
-            this.toolStripMenuItem78.Text = "Items not on Scene releases";
+            this.toolStripMenuItem78.Size = new System.Drawing.Size(215, 22);
+            this.toolStripMenuItem78.Text = "Items not in Scene releases";
             // 
             // toolStripMenuItem79
             // 
@@ -2853,7 +3598,7 @@
             // 
             this.toolStripMenuItem80.Name = "toolStripMenuItem80";
             this.toolStripMenuItem80.Size = new System.Drawing.Size(116, 22);
-            this.toolStripMenuItem80.Text = "SD card";
+            this.toolStripMenuItem80.Text = "SD Card";
             this.toolStripMenuItem80.Visible = false;
             // 
             // toolStripMenuItem81
@@ -2971,760 +3716,17 @@
             this.toolStripMenuItem95.Size = new System.Drawing.Size(107, 22);
             this.toolStripMenuItem95.Text = "CSV";
             // 
-            // tabPage4
-            // 
-            this.tabPage4.Controls.Add(this.panel10);
-            this.tabPage4.Controls.Add(this.panel11);
-            this.tabPage4.Location = new System.Drawing.Point(4, 22);
-            this.tabPage4.Name = "tabPage4";
-            this.tabPage4.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage4.Size = new System.Drawing.Size(1517, 366);
-            this.tabPage4.TabIndex = 3;
-            this.tabPage4.Text = "E-shop files";
-            this.tabPage4.UseVisualStyleBackColor = true;
-            // 
-            // panel10
-            // 
-            this.panel10.Controls.Add(this.OLVEshop);
-            this.panel10.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel10.Location = new System.Drawing.Point(3, 31);
-            this.panel10.Name = "panel10";
-            this.panel10.Size = new System.Drawing.Size(1511, 332);
-            this.panel10.TabIndex = 11;
-            // 
-            // OLVEshop
-            // 
-            this.OLVEshop.AllColumns.Add(this.olvColumnTitleIDEShop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnGameNameEShop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnROMSizeEshop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnLanguagesEShop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnFilePathEShop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnDeveloperEShop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnPublisherEshop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnGameRevisionEShop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnVersionEShop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnLatestEShop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnMasterKeyRevisionEShop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnDistributionType);
-            this.OLVEshop.AllColumns.Add(this.olvColumnFirmwareEShop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnSDKVersionEShop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnReleaseDateEshop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnNumberOfPlayersEshop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnCategoriesEShop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnContentTypeEShop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnImportedDateEShop);
-            this.OLVEshop.AllColumns.Add(this.olvColumnSourceEShop);
-            this.OLVEshop.CellEditUseWholeCell = false;
-            this.OLVEshop.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.olvColumnTitleIDEShop,
-            this.olvColumnGameNameEShop,
-            this.olvColumnROMSizeEshop,
-            this.olvColumnLanguagesEShop,
-            this.olvColumnFilePathEShop,
-            this.olvColumnDeveloperEShop,
-            this.olvColumnPublisherEshop,
-            this.olvColumnGameRevisionEShop,
-            this.olvColumnVersionEShop,
-            this.olvColumnLatestEShop,
-            this.olvColumnMasterKeyRevisionEShop,
-            this.olvColumnDistributionType,
-            this.olvColumnFirmwareEShop,
-            this.olvColumnSDKVersionEShop,
-            this.olvColumnReleaseDateEshop,
-            this.olvColumnNumberOfPlayersEshop,
-            this.olvColumnCategoriesEShop,
-            this.olvColumnContentTypeEShop,
-            this.olvColumnImportedDateEShop,
-            this.olvColumnSourceEShop});
-            this.OLVEshop.ContextMenuStrip = this.contextMenuEShopList;
-            this.OLVEshop.Cursor = System.Windows.Forms.Cursors.Default;
-            this.OLVEshop.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.OLVEshop.FullRowSelect = true;
-            this.OLVEshop.GridLines = true;
-            this.OLVEshop.Location = new System.Drawing.Point(0, 0);
-            this.OLVEshop.Name = "OLVEshop";
-            this.OLVEshop.ShowGroups = false;
-            this.OLVEshop.Size = new System.Drawing.Size(1511, 332);
-            this.OLVEshop.TabIndex = 3;
-            this.OLVEshop.UseCellFormatEvents = true;
-            this.OLVEshop.UseCompatibleStateImageBehavior = false;
-            this.OLVEshop.UseExplorerTheme = true;
-            this.OLVEshop.View = System.Windows.Forms.View.Details;
-            this.OLVEshop.CellOver += new System.EventHandler<BrightIdeasSoftware.CellOverEventArgs>(this.OLVEshop_CellOver);
-            this.OLVEshop.FormatCell += new System.EventHandler<BrightIdeasSoftware.FormatCellEventArgs>(this.OLVEshop_FormatCell);
-            this.OLVEshop.ItemSelectionChanged += new System.Windows.Forms.ListViewItemSelectionChangedEventHandler(this.OLVEshop_ItemSelectionChanged);
-            this.OLVEshop.KeyDown += new System.Windows.Forms.KeyEventHandler(this.OLVEshop_KeyDown);
-            // 
-            // olvColumnTitleIDEShop
-            // 
-            this.olvColumnTitleIDEShop.AspectName = "TitleID";
-            this.olvColumnTitleIDEShop.Text = "Title ID";
-            this.olvColumnTitleIDEShop.Width = 200;
-            // 
-            // olvColumnGameNameEShop
-            // 
-            this.olvColumnGameNameEShop.AspectName = "GameName";
-            this.olvColumnGameNameEShop.Text = "Game title";
-            this.olvColumnGameNameEShop.UseInitialLetterForGroup = true;
-            this.olvColumnGameNameEShop.Width = 280;
-            // 
-            // olvColumnROMSizeEshop
-            // 
-            this.olvColumnROMSizeEshop.AspectName = "ROMSizeBytes";
-            this.olvColumnROMSizeEshop.Text = "ROM size";
-            this.olvColumnROMSizeEshop.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-            this.olvColumnROMSizeEshop.UseInitialLetterForGroup = true;
-            this.olvColumnROMSizeEshop.Width = 65;
-            // 
-            // olvColumnLanguagesEShop
-            // 
-            this.olvColumnLanguagesEShop.AspectName = "Languages";
-            this.olvColumnLanguagesEShop.Text = "Languages";
-            this.olvColumnLanguagesEShop.Width = 100;
-            // 
-            // olvColumnFilePathEShop
-            // 
-            this.olvColumnFilePathEShop.AspectName = "FilePath";
-            this.olvColumnFilePathEShop.Text = "Filename";
-            this.olvColumnFilePathEShop.UseInitialLetterForGroup = true;
-            this.olvColumnFilePathEShop.Width = 280;
-            // 
-            // olvColumnDeveloperEShop
-            // 
-            this.olvColumnDeveloperEShop.AspectName = "Developer";
-            this.olvColumnDeveloperEShop.Text = "Developer";
-            this.olvColumnDeveloperEShop.Width = 204;
-            // 
-            // olvColumnPublisherEshop
-            // 
-            this.olvColumnPublisherEshop.AspectName = "Publisher ";
-            this.olvColumnPublisherEshop.Text = "Publisher";
-            // 
-            // olvColumnGameRevisionEShop
-            // 
-            this.olvColumnGameRevisionEShop.AspectName = "GameRevision";
-            this.olvColumnGameRevisionEShop.Text = "Game revision";
-            this.olvColumnGameRevisionEShop.UseInitialLetterForGroup = true;
-            this.olvColumnGameRevisionEShop.Width = 100;
-            // 
-            // olvColumnVersionEShop
-            // 
-            this.olvColumnVersionEShop.AspectName = "Version";
-            this.olvColumnVersionEShop.Text = "Version";
-            this.olvColumnVersionEShop.Width = 100;
-            // 
-            // olvColumnLatestEShop
-            // 
-            this.olvColumnLatestEShop.AspectName = "Latest";
-            this.olvColumnLatestEShop.Text = "Latest";
-            this.olvColumnLatestEShop.Width = 100;
-            // 
-            // olvColumnMasterKeyRevisionEShop
-            // 
-            this.olvColumnMasterKeyRevisionEShop.AspectName = "MasterKeyRevision";
-            this.olvColumnMasterKeyRevisionEShop.Text = "Masterkey revision";
-            this.olvColumnMasterKeyRevisionEShop.Width = 135;
-            // 
-            // olvColumnDistributionType
-            // 
-            this.olvColumnDistributionType.AspectName = "DistributionType";
-            this.olvColumnDistributionType.Text = "Distribution";
-            this.olvColumnDistributionType.Width = 72;
-            // 
-            // olvColumnFirmwareEShop
-            // 
-            this.olvColumnFirmwareEShop.AspectName = "Firmware";
-            this.olvColumnFirmwareEShop.Text = "Firmware";
-            this.olvColumnFirmwareEShop.Width = 100;
-            // 
-            // olvColumnSDKVersionEShop
-            // 
-            this.olvColumnSDKVersionEShop.AspectName = "SDKVersion";
-            this.olvColumnSDKVersionEShop.Text = "SDK Version";
-            this.olvColumnSDKVersionEShop.Width = 100;
-            // 
-            // olvColumnReleaseDateEshop
-            // 
-            this.olvColumnReleaseDateEshop.AspectName = "ReleaseDate ";
-            this.olvColumnReleaseDateEshop.Text = "Release date";
-            this.olvColumnReleaseDateEshop.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            // 
-            // olvColumnNumberOfPlayersEshop
-            // 
-            this.olvColumnNumberOfPlayersEshop.AspectName = "NumberOfPlayers ";
-            this.olvColumnNumberOfPlayersEshop.Text = "Nº of players";
-            this.olvColumnNumberOfPlayersEshop.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            // 
-            // olvColumnCategoriesEShop
-            // 
-            this.olvColumnCategoriesEShop.AspectName = "Categories ";
-            this.olvColumnCategoriesEShop.Text = "Category";
-            // 
-            // olvColumnContentTypeEShop
-            // 
-            this.olvColumnContentTypeEShop.AspectName = "ContentType";
-            this.olvColumnContentTypeEShop.Text = "Content Type";
-            // 
-            // olvColumnImportedDateEShop
-            // 
-            this.olvColumnImportedDateEShop.AspectName = "ImportedDate";
-            this.olvColumnImportedDateEShop.IsEditable = false;
-            this.olvColumnImportedDateEShop.Text = "Imported Date";
-            // 
-            // olvColumnSourceEShop
-            // 
-            this.olvColumnSourceEShop.AspectName = "Source";
-            this.olvColumnSourceEShop.Text = "Source";
-            this.olvColumnSourceEShop.Width = 80;
-            // 
-            // contextMenuEShopList
-            // 
-            this.contextMenuEShopList.ImageScalingSize = new System.Drawing.Size(24, 24);
-            this.contextMenuEShopList.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemEShopShowInExplorer,
-            this.toolStripMenuItemEShopUpdateInfo,
-            this.toolStripSeparator9,
-            this.toolStripMenuItemEShopAutoRename,
-            this.toolStripSeparator10,
-            this.toolStripMenuItemEShopCopyToFolder,
-            this.toolStripMenuItemEShopMoveToFolder,
-            this.toolStripMenuItem64,
-            this.copyInfoToClipboardToolStripMenuItem,
-            this.updateGameInfoFromWebToolStripMenuItemEshop,
-            this.toolStripMenuItem97Eshop,
-            this.deleteSelectedFilesToolStripMenuItemEshop});
-            this.contextMenuEShopList.Name = "contextMenuStripSDCard";
-            this.contextMenuEShopList.Size = new System.Drawing.Size(277, 204);
-            this.contextMenuEShopList.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStripEShop_Opening);
-            // 
-            // toolStripMenuItemEShopShowInExplorer
-            // 
-            this.toolStripMenuItemEShopShowInExplorer.Name = "toolStripMenuItemEShopShowInExplorer";
-            this.toolStripMenuItemEShopShowInExplorer.Size = new System.Drawing.Size(276, 22);
-            this.toolStripMenuItemEShopShowInExplorer.Text = "Show in explorer";
-            this.toolStripMenuItemEShopShowInExplorer.Click += new System.EventHandler(this.toolStripMenuItemEShopShowInExplorer_Click);
-            // 
-            // toolStripMenuItemEShopUpdateInfo
-            // 
-            this.toolStripMenuItemEShopUpdateInfo.Name = "toolStripMenuItemEShopUpdateInfo";
-            this.toolStripMenuItemEShopUpdateInfo.Size = new System.Drawing.Size(276, 22);
-            this.toolStripMenuItemEShopUpdateInfo.Text = "Update info";
-            this.toolStripMenuItemEShopUpdateInfo.Visible = false;
-            this.toolStripMenuItemEShopUpdateInfo.Click += new System.EventHandler(this.toolStripMenuItemEShopUpdateInfo_Click);
-            // 
-            // toolStripSeparator9
-            // 
-            this.toolStripSeparator9.Name = "toolStripSeparator9";
-            this.toolStripSeparator9.Size = new System.Drawing.Size(273, 6);
-            // 
-            // toolStripMenuItemEShopAutoRename
-            // 
-            this.toolStripMenuItemEShopAutoRename.Name = "toolStripMenuItemEShopAutoRename";
-            this.toolStripMenuItemEShopAutoRename.Size = new System.Drawing.Size(276, 22);
-            this.toolStripMenuItemEShopAutoRename.Text = "Auto rename files";
-            this.toolStripMenuItemEShopAutoRename.Click += new System.EventHandler(this.toolStripMenuItemEShopAutoRename_Click);
-            // 
-            // toolStripSeparator10
-            // 
-            this.toolStripSeparator10.Name = "toolStripSeparator10";
-            this.toolStripSeparator10.Size = new System.Drawing.Size(273, 6);
-            // 
-            // toolStripMenuItemEShopCopyToFolder
-            // 
-            this.toolStripMenuItemEShopCopyToFolder.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.sDCardToolStripMenuItem4,
-            this.folderToolStripMenuItem5});
-            this.toolStripMenuItemEShopCopyToFolder.Name = "toolStripMenuItemEShopCopyToFolder";
-            this.toolStripMenuItemEShopCopyToFolder.Size = new System.Drawing.Size(276, 22);
-            this.toolStripMenuItemEShopCopyToFolder.Text = "Copy files to";
-            // 
-            // sDCardToolStripMenuItem4
-            // 
-            this.sDCardToolStripMenuItem4.Name = "sDCardToolStripMenuItem4";
-            this.sDCardToolStripMenuItem4.Size = new System.Drawing.Size(116, 22);
-            this.sDCardToolStripMenuItem4.Text = "SD card";
-            this.sDCardToolStripMenuItem4.Click += new System.EventHandler(this.sDCardToolStripMenuItem4_Click);
-            // 
-            // folderToolStripMenuItem5
-            // 
-            this.folderToolStripMenuItem5.Name = "folderToolStripMenuItem5";
-            this.folderToolStripMenuItem5.Size = new System.Drawing.Size(116, 22);
-            this.folderToolStripMenuItem5.Text = "Folder...";
-            this.folderToolStripMenuItem5.Click += new System.EventHandler(this.folderToolStripMenuItem5_Click);
-            // 
-            // toolStripMenuItemEShopMoveToFolder
-            // 
-            this.toolStripMenuItemEShopMoveToFolder.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.sDCardToolStripMenuItem5,
-            this.folderToolStripMenuItem6});
-            this.toolStripMenuItemEShopMoveToFolder.Name = "toolStripMenuItemEShopMoveToFolder";
-            this.toolStripMenuItemEShopMoveToFolder.Size = new System.Drawing.Size(276, 22);
-            this.toolStripMenuItemEShopMoveToFolder.Text = "Move files to";
-            // 
-            // sDCardToolStripMenuItem5
-            // 
-            this.sDCardToolStripMenuItem5.Name = "sDCardToolStripMenuItem5";
-            this.sDCardToolStripMenuItem5.Size = new System.Drawing.Size(116, 22);
-            this.sDCardToolStripMenuItem5.Text = "SD card";
-            this.sDCardToolStripMenuItem5.Click += new System.EventHandler(this.sDCardToolStripMenuItem5_Click);
-            // 
-            // folderToolStripMenuItem6
-            // 
-            this.folderToolStripMenuItem6.Name = "folderToolStripMenuItem6";
-            this.folderToolStripMenuItem6.Size = new System.Drawing.Size(116, 22);
-            this.folderToolStripMenuItem6.Text = "Folder...";
-            this.folderToolStripMenuItem6.Click += new System.EventHandler(this.folderToolStripMenuItem6_Click);
-            // 
-            // toolStripMenuItem64
-            // 
-            this.toolStripMenuItem64.Name = "toolStripMenuItem64";
-            this.toolStripMenuItem64.Size = new System.Drawing.Size(273, 6);
-            // 
-            // copyInfoToClipboardToolStripMenuItem
-            // 
-            this.copyInfoToClipboardToolStripMenuItem.Name = "copyInfoToClipboardToolStripMenuItem";
-            this.copyInfoToClipboardToolStripMenuItem.Size = new System.Drawing.Size(276, 22);
-            this.copyInfoToClipboardToolStripMenuItem.Text = "Copy info to clipboard";
-            this.copyInfoToClipboardToolStripMenuItem.Click += new System.EventHandler(this.copyInfoToClipboardToolStripMenuItem_Click);
-            // 
-            // updateGameInfoFromWebToolStripMenuItemEshop
-            // 
-            this.updateGameInfoFromWebToolStripMenuItemEshop.Name = "updateGameInfoFromWebToolStripMenuItemEshop";
-            this.updateGameInfoFromWebToolStripMenuItemEshop.Size = new System.Drawing.Size(276, 22);
-            this.updateGameInfoFromWebToolStripMenuItemEshop.Text = "Update game info from Web";
-            this.updateGameInfoFromWebToolStripMenuItemEshop.Click += new System.EventHandler(this.updateGameInfoFromWebToolStripMenuItemEshop_Click);
-            // 
-            // toolStripMenuItem97Eshop
-            // 
-            this.toolStripMenuItem97Eshop.Name = "toolStripMenuItem97Eshop";
-            this.toolStripMenuItem97Eshop.Size = new System.Drawing.Size(273, 6);
-            // 
-            // deleteSelectedFilesToolStripMenuItemEshop
-            // 
-            this.deleteSelectedFilesToolStripMenuItemEshop.Name = "deleteSelectedFilesToolStripMenuItemEshop";
-            this.deleteSelectedFilesToolStripMenuItemEshop.Size = new System.Drawing.Size(276, 22);
-            this.deleteSelectedFilesToolStripMenuItemEshop.Text = "Delete selected files (erases from disk!)";
-            this.deleteSelectedFilesToolStripMenuItemEshop.Click += new System.EventHandler(this.deleteSelectedFilesToolStripMenuItemEshop_Click);
-            // 
-            // panel11
-            // 
-            this.panel11.Controls.Add(this.panel13);
-            this.panel11.Controls.Add(this.panel12);
-            this.panel11.Dock = System.Windows.Forms.DockStyle.Top;
-            this.panel11.Location = new System.Drawing.Point(3, 3);
-            this.panel11.Name = "panel11";
-            this.panel11.Size = new System.Drawing.Size(1511, 28);
-            this.panel11.TabIndex = 10;
-            // 
-            // panel13
-            // 
-            this.panel13.Controls.Add(this.cbBaseGame);
-            this.panel13.Controls.Add(this.cbUpdates);
-            this.panel13.Controls.Add(this.cbDLC);
-            this.panel13.Controls.Add(this.btnClearFilterEShop);
-            this.panel13.Controls.Add(this.textBoxFilterEShop);
-            this.panel13.Controls.Add(this.label5);
-            this.panel13.Controls.Add(this.cbxFilterEshop);
-            this.panel13.Dock = System.Windows.Forms.DockStyle.Right;
-            this.panel13.Location = new System.Drawing.Point(798, 0);
-            this.panel13.Name = "panel13";
-            this.panel13.Size = new System.Drawing.Size(713, 28);
-            this.panel13.TabIndex = 1;
-            // 
-            // cbBaseGame
-            // 
-            this.cbBaseGame.AutoSize = true;
-            this.cbBaseGame.Checked = true;
-            this.cbBaseGame.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbBaseGame.Location = new System.Drawing.Point(126, 5);
-            this.cbBaseGame.Name = "cbBaseGame";
-            this.cbBaseGame.Size = new System.Drawing.Size(79, 17);
-            this.cbBaseGame.TabIndex = 20;
-            this.cbBaseGame.Text = "Base game";
-            this.cbBaseGame.UseVisualStyleBackColor = true;
-            this.cbBaseGame.CheckedChanged += new System.EventHandler(this.cbBaseGame_CheckedChanged);
-            // 
-            // cbUpdates
-            // 
-            this.cbUpdates.AutoSize = true;
-            this.cbUpdates.Checked = true;
-            this.cbUpdates.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbUpdates.Location = new System.Drawing.Point(58, 5);
-            this.cbUpdates.Name = "cbUpdates";
-            this.cbUpdates.Size = new System.Drawing.Size(61, 17);
-            this.cbUpdates.TabIndex = 19;
-            this.cbUpdates.Text = "Update";
-            this.cbUpdates.UseVisualStyleBackColor = true;
-            this.cbUpdates.CheckedChanged += new System.EventHandler(this.cbUpdates_CheckedChanged);
-            // 
-            // cbDLC
-            // 
-            this.cbDLC.AutoSize = true;
-            this.cbDLC.Location = new System.Drawing.Point(4, 5);
-            this.cbDLC.Name = "cbDLC";
-            this.cbDLC.Size = new System.Drawing.Size(47, 17);
-            this.cbDLC.TabIndex = 18;
-            this.cbDLC.Text = "DLC";
-            this.cbDLC.UseVisualStyleBackColor = true;
-            this.cbDLC.CheckedChanged += new System.EventHandler(this.cbDLC_CheckedChanged);
-            // 
-            // btnClearFilterEShop
-            // 
-            this.btnClearFilterEShop.Location = new System.Drawing.Point(634, 2);
-            this.btnClearFilterEShop.Name = "btnClearFilterEShop";
-            this.btnClearFilterEShop.Size = new System.Drawing.Size(75, 23);
-            this.btnClearFilterEShop.TabIndex = 17;
-            this.btnClearFilterEShop.Text = "Clear";
-            this.btnClearFilterEShop.UseVisualStyleBackColor = true;
-            this.btnClearFilterEShop.Click += new System.EventHandler(this.btnClearFilterEShop_Click);
-            // 
-            // textBoxFilterEShop
-            // 
-            this.textBoxFilterEShop.Location = new System.Drawing.Point(359, 4);
-            this.textBoxFilterEShop.Name = "textBoxFilterEShop";
-            this.textBoxFilterEShop.Size = new System.Drawing.Size(268, 20);
-            this.textBoxFilterEShop.TabIndex = 16;
-            this.textBoxFilterEShop.TextChanged += new System.EventHandler(this.textBoxFilterEShop_TextChanged);
-            // 
-            // label5
-            // 
-            this.label5.AutoSize = true;
-            this.label5.BackColor = System.Drawing.SystemColors.Window;
-            this.label5.Location = new System.Drawing.Point(215, 7);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(32, 13);
-            this.label5.TabIndex = 15;
-            this.label5.Text = "Filter:";
-            // 
-            // cbxFilterEshop
-            // 
-            this.cbxFilterEshop.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cbxFilterEshop.FormattingEnabled = true;
-            this.cbxFilterEshop.Location = new System.Drawing.Point(250, 3);
-            this.cbxFilterEshop.Name = "cbxFilterEshop";
-            this.cbxFilterEshop.Size = new System.Drawing.Size(102, 21);
-            this.cbxFilterEshop.TabIndex = 14;
-            this.cbxFilterEshop.SelectedIndexChanged += new System.EventHandler(this.cbxFilterEshop_SelectedIndexChanged);
-            // 
-            // panel12
-            // 
-            this.panel12.Controls.Add(this.menuEShop);
-            this.panel12.Dock = System.Windows.Forms.DockStyle.Left;
-            this.panel12.Location = new System.Drawing.Point(0, 0);
-            this.panel12.Name = "panel12";
-            this.panel12.Size = new System.Drawing.Size(777, 28);
-            this.panel12.TabIndex = 0;
-            // 
-            // menuEShop
-            // 
-            this.menuEShop.ImageScalingSize = new System.Drawing.Size(24, 24);
-            this.menuEShop.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.addToolStripMenuItemAddFolderEShop,
-            this.toolStripMenuItemSelectEshop,
-            this.toolStripMenuItem22,
-            this.toolStripMenuItem23,
-            this.toolStripMenuItem24});
-            this.menuEShop.Location = new System.Drawing.Point(0, 0);
-            this.menuEShop.Name = "menuEShop";
-            this.menuEShop.Size = new System.Drawing.Size(777, 24);
-            this.menuEShop.TabIndex = 9;
-            this.menuEShop.Text = "menuStrip2";
-            // 
-            // addToolStripMenuItemAddFolderEShop
-            // 
-            this.addToolStripMenuItemAddFolderEShop.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.filesToolStripMenuItem1,
-            this.folderToolStripMenuItem4});
-            this.addToolStripMenuItemAddFolderEShop.Name = "addToolStripMenuItemAddFolderEShop";
-            this.addToolStripMenuItemAddFolderEShop.Size = new System.Drawing.Size(41, 20);
-            this.addToolStripMenuItemAddFolderEShop.Text = "Add";
-            // 
-            // filesToolStripMenuItem1
-            // 
-            this.filesToolStripMenuItem1.Name = "filesToolStripMenuItem1";
-            this.filesToolStripMenuItem1.Size = new System.Drawing.Size(116, 22);
-            this.filesToolStripMenuItem1.Text = "Files...";
-            this.filesToolStripMenuItem1.Click += new System.EventHandler(this.filesToolStripMenuItem1_Click);
-            // 
-            // folderToolStripMenuItem4
-            // 
-            this.folderToolStripMenuItem4.Name = "folderToolStripMenuItem4";
-            this.folderToolStripMenuItem4.Size = new System.Drawing.Size(116, 22);
-            this.folderToolStripMenuItem4.Text = "Folder...";
-            this.folderToolStripMenuItem4.Click += new System.EventHandler(this.folderToolStripMenuItem4_Click);
-            // 
-            // toolStripMenuItemSelectEshop
-            // 
-            this.toolStripMenuItemSelectEshop.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemSelectAllEshop,
-            this.toolStripMenuItemSelectNoneEShop,
-            this.toolStripMenuItemSelectInvertEShop,
-            this.toolStripSeparator7,
-            this.toolStripMenuItemSelectSDCardEShop,
-            this.toolStripMenuItemSelectSceneEShop,
-            this.toolStripMenuItem97,
-            this.outdatedToolStripMenuItem});
-            this.toolStripMenuItemSelectEshop.Name = "toolStripMenuItemSelectEshop";
-            this.toolStripMenuItemSelectEshop.Size = new System.Drawing.Size(50, 20);
-            this.toolStripMenuItemSelectEshop.Text = "&Select";
-            // 
-            // toolStripMenuItemSelectAllEshop
-            // 
-            this.toolStripMenuItemSelectAllEshop.Name = "toolStripMenuItemSelectAllEshop";
-            this.toolStripMenuItemSelectAllEshop.Size = new System.Drawing.Size(169, 22);
-            this.toolStripMenuItemSelectAllEshop.Text = "All";
-            this.toolStripMenuItemSelectAllEshop.Click += new System.EventHandler(this.toolStripMenuItemSelectAllEshop_Click);
-            // 
-            // toolStripMenuItemSelectNoneEShop
-            // 
-            this.toolStripMenuItemSelectNoneEShop.Name = "toolStripMenuItemSelectNoneEShop";
-            this.toolStripMenuItemSelectNoneEShop.Size = new System.Drawing.Size(169, 22);
-            this.toolStripMenuItemSelectNoneEShop.Text = "None";
-            this.toolStripMenuItemSelectNoneEShop.Click += new System.EventHandler(this.toolStripMenuItemSelectNoneEShop_Click);
-            // 
-            // toolStripMenuItemSelectInvertEShop
-            // 
-            this.toolStripMenuItemSelectInvertEShop.Name = "toolStripMenuItemSelectInvertEShop";
-            this.toolStripMenuItemSelectInvertEShop.Size = new System.Drawing.Size(169, 22);
-            this.toolStripMenuItemSelectInvertEShop.Text = "Invert selection";
-            this.toolStripMenuItemSelectInvertEShop.Click += new System.EventHandler(this.toolStripMenuItemSelectInvertEShop_Click);
-            // 
-            // toolStripSeparator7
-            // 
-            this.toolStripSeparator7.Name = "toolStripSeparator7";
-            this.toolStripSeparator7.Size = new System.Drawing.Size(166, 6);
-            // 
-            // toolStripMenuItemSelectSDCardEShop
-            // 
-            this.toolStripMenuItemSelectSDCardEShop.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemSelectSDCardItemsOnSDEShop,
-            this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop});
-            this.toolStripMenuItemSelectSDCardEShop.Name = "toolStripMenuItemSelectSDCardEShop";
-            this.toolStripMenuItemSelectSDCardEShop.Size = new System.Drawing.Size(169, 22);
-            this.toolStripMenuItemSelectSDCardEShop.Text = "SD card";
-            // 
-            // toolStripMenuItemSelectSDCardItemsOnSDEShop
-            // 
-            this.toolStripMenuItemSelectSDCardItemsOnSDEShop.Name = "toolStripMenuItemSelectSDCardItemsOnSDEShop";
-            this.toolStripMenuItemSelectSDCardItemsOnSDEShop.Size = new System.Drawing.Size(184, 22);
-            this.toolStripMenuItemSelectSDCardItemsOnSDEShop.Text = "Items on SD card";
-            this.toolStripMenuItemSelectSDCardItemsOnSDEShop.Click += new System.EventHandler(this.toolStripMenuItemSelectSDCardItemsOnSDEShop_Click);
-            // 
-            // toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop
-            // 
-            this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop.Name = "toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop";
-            this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop.Size = new System.Drawing.Size(184, 22);
-            this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop.Text = "Items not on SD card";
-            this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop.Click += new System.EventHandler(this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop_Click);
-            // 
-            // toolStripMenuItemSelectSceneEShop
-            // 
-            this.toolStripMenuItemSelectSceneEShop.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemSelectSceneOnEShop,
-            this.toolStripMenuItemSelectSceneNotOnEShop});
-            this.toolStripMenuItemSelectSceneEShop.Name = "toolStripMenuItemSelectSceneEShop";
-            this.toolStripMenuItemSelectSceneEShop.Size = new System.Drawing.Size(169, 22);
-            this.toolStripMenuItemSelectSceneEShop.Text = "Scene releases";
-            this.toolStripMenuItemSelectSceneEShop.Visible = false;
-            // 
-            // toolStripMenuItemSelectSceneOnEShop
-            // 
-            this.toolStripMenuItemSelectSceneOnEShop.Name = "toolStripMenuItemSelectSceneOnEShop";
-            this.toolStripMenuItemSelectSceneOnEShop.Size = new System.Drawing.Size(219, 22);
-            this.toolStripMenuItemSelectSceneOnEShop.Text = "Items on Scene releases";
-            this.toolStripMenuItemSelectSceneOnEShop.Click += new System.EventHandler(this.toolStripMenuItemSelectSceneOnEShop_Click);
-            // 
-            // toolStripMenuItemSelectSceneNotOnEShop
-            // 
-            this.toolStripMenuItemSelectSceneNotOnEShop.Name = "toolStripMenuItemSelectSceneNotOnEShop";
-            this.toolStripMenuItemSelectSceneNotOnEShop.Size = new System.Drawing.Size(219, 22);
-            this.toolStripMenuItemSelectSceneNotOnEShop.Text = "Items not on Scene releases";
-            // 
-            // toolStripMenuItem97
-            // 
-            this.toolStripMenuItem97.Name = "toolStripMenuItem97";
-            this.toolStripMenuItem97.Size = new System.Drawing.Size(166, 6);
-            // 
-            // outdatedToolStripMenuItem
-            // 
-            this.outdatedToolStripMenuItem.Name = "outdatedToolStripMenuItem";
-            this.outdatedToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
-            this.outdatedToolStripMenuItem.Text = "Outdated updates";
-            this.outdatedToolStripMenuItem.Click += new System.EventHandler(this.outdatedToolStripMenuItem_Click);
-            // 
-            // toolStripMenuItem22
-            // 
-            this.toolStripMenuItem22.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemGroupingNoneEShop,
-            this.toolStripMenuItemGroupingGameTitleEShop,
-            this.toolStripMenuItemGroupingDeveloperEShop,
-            this.toolStripMenuItemGroupingMasterKeyEShop});
-            this.toolStripMenuItem22.Name = "toolStripMenuItem22";
-            this.toolStripMenuItem22.Size = new System.Drawing.Size(69, 20);
-            this.toolStripMenuItem22.Text = "&Grouping";
-            // 
-            // toolStripMenuItemGroupingNoneEShop
-            // 
-            this.toolStripMenuItemGroupingNoneEShop.Name = "toolStripMenuItemGroupingNoneEShop";
-            this.toolStripMenuItemGroupingNoneEShop.Size = new System.Drawing.Size(172, 22);
-            this.toolStripMenuItemGroupingNoneEShop.Text = "None";
-            this.toolStripMenuItemGroupingNoneEShop.Click += new System.EventHandler(this.toolStripMenuItemGroupingNoneEShop_Click);
-            // 
-            // toolStripMenuItemGroupingGameTitleEShop
-            // 
-            this.toolStripMenuItemGroupingGameTitleEShop.Name = "toolStripMenuItemGroupingGameTitleEShop";
-            this.toolStripMenuItemGroupingGameTitleEShop.Size = new System.Drawing.Size(172, 22);
-            this.toolStripMenuItemGroupingGameTitleEShop.Text = "Game title";
-            this.toolStripMenuItemGroupingGameTitleEShop.Click += new System.EventHandler(this.toolStripMenuItemGroupingGameTitleEShop_Click);
-            // 
-            // toolStripMenuItemGroupingDeveloperEShop
-            // 
-            this.toolStripMenuItemGroupingDeveloperEShop.Name = "toolStripMenuItemGroupingDeveloperEShop";
-            this.toolStripMenuItemGroupingDeveloperEShop.Size = new System.Drawing.Size(172, 22);
-            this.toolStripMenuItemGroupingDeveloperEShop.Text = "Developer";
-            this.toolStripMenuItemGroupingDeveloperEShop.Click += new System.EventHandler(this.toolStripMenuItemGroupingDeveloperEShop_Click);
-            // 
-            // toolStripMenuItemGroupingMasterKeyEShop
-            // 
-            this.toolStripMenuItemGroupingMasterKeyEShop.Name = "toolStripMenuItemGroupingMasterKeyEShop";
-            this.toolStripMenuItemGroupingMasterKeyEShop.Size = new System.Drawing.Size(172, 22);
-            this.toolStripMenuItemGroupingMasterKeyEShop.Text = "Masterkey revision";
-            this.toolStripMenuItemGroupingMasterKeyEShop.Click += new System.EventHandler(this.toolStripMenuItemGroupingMasterKeyEShop_Click);
-            // 
-            // toolStripMenuItem23
-            // 
-            this.toolStripMenuItem23.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemRemoveSelectedEShop,
-            this.toolStripSeparator8,
-            this.toolStripMenuItem44,
-            this.toolStripMenuItem65});
-            this.toolStripMenuItem23.Name = "toolStripMenuItem23";
-            this.toolStripMenuItem23.Size = new System.Drawing.Size(117, 20);
-            this.toolStripMenuItem23.Text = "&Remove (from list)";
-            // 
-            // toolStripMenuItemRemoveSelectedEShop
-            // 
-            this.toolStripMenuItemRemoveSelectedEShop.Name = "toolStripMenuItemRemoveSelectedEShop";
-            this.toolStripMenuItemRemoveSelectedEShop.Size = new System.Drawing.Size(149, 22);
-            this.toolStripMenuItemRemoveSelectedEShop.Text = "Selected";
-            this.toolStripMenuItemRemoveSelectedEShop.Click += new System.EventHandler(this.toolStripMenuItemRemoveSelectedEShop_Click);
-            // 
-            // toolStripSeparator8
-            // 
-            this.toolStripSeparator8.Name = "toolStripSeparator8";
-            this.toolStripSeparator8.Size = new System.Drawing.Size(146, 6);
-            this.toolStripSeparator8.Visible = false;
-            // 
-            // toolStripMenuItem44
-            // 
-            this.toolStripMenuItem44.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemRemoveFilesOnSDCardEShop,
-            this.toolStripMenuItemRemoveFilesNotOnSDCardEShop});
-            this.toolStripMenuItem44.Name = "toolStripMenuItem44";
-            this.toolStripMenuItem44.Size = new System.Drawing.Size(149, 22);
-            this.toolStripMenuItem44.Text = "SD card";
-            this.toolStripMenuItem44.Visible = false;
-            // 
-            // toolStripMenuItemRemoveFilesOnSDCardEShop
-            // 
-            this.toolStripMenuItemRemoveFilesOnSDCardEShop.Name = "toolStripMenuItemRemoveFilesOnSDCardEShop";
-            this.toolStripMenuItemRemoveFilesOnSDCardEShop.Size = new System.Drawing.Size(184, 22);
-            this.toolStripMenuItemRemoveFilesOnSDCardEShop.Text = "Items on SD card";
-            // 
-            // toolStripMenuItemRemoveFilesNotOnSDCardEShop
-            // 
-            this.toolStripMenuItemRemoveFilesNotOnSDCardEShop.Name = "toolStripMenuItemRemoveFilesNotOnSDCardEShop";
-            this.toolStripMenuItemRemoveFilesNotOnSDCardEShop.Size = new System.Drawing.Size(184, 22);
-            this.toolStripMenuItemRemoveFilesNotOnSDCardEShop.Text = "Items not on SD card";
-            // 
-            // toolStripMenuItem65
-            // 
-            this.toolStripMenuItem65.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItem66,
-            this.toolStripMenuItem67});
-            this.toolStripMenuItem65.Name = "toolStripMenuItem65";
-            this.toolStripMenuItem65.Size = new System.Drawing.Size(149, 22);
-            this.toolStripMenuItem65.Text = "Scene releases";
-            this.toolStripMenuItem65.Visible = false;
-            // 
-            // toolStripMenuItem66
-            // 
-            this.toolStripMenuItem66.Name = "toolStripMenuItem66";
-            this.toolStripMenuItem66.Size = new System.Drawing.Size(219, 22);
-            this.toolStripMenuItem66.Text = "Items on Scene releases";
-            // 
-            // toolStripMenuItem67
-            // 
-            this.toolStripMenuItem67.Name = "toolStripMenuItem67";
-            this.toolStripMenuItem67.Size = new System.Drawing.Size(219, 22);
-            this.toolStripMenuItem67.Text = "Items not on Scene releases";
-            // 
-            // toolStripMenuItem24
-            // 
-            this.toolStripMenuItem24.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItem45,
-            this.toolStripMenuItem69});
-            this.toolStripMenuItem24.Name = "toolStripMenuItem24";
-            this.toolStripMenuItem24.Size = new System.Drawing.Size(75, 20);
-            this.toolStripMenuItem24.Text = "&Transfer to";
-            // 
-            // toolStripMenuItem45
-            // 
-            this.toolStripMenuItem45.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemCopyFilesToSDEShop,
-            this.toolStripMenuItemMoveFilesToSDEShop});
-            this.toolStripMenuItem45.Name = "toolStripMenuItem45";
-            this.toolStripMenuItem45.Size = new System.Drawing.Size(116, 22);
-            this.toolStripMenuItem45.Text = "SD card";
-            // 
-            // toolStripMenuItemCopyFilesToSDEShop
-            // 
-            this.toolStripMenuItemCopyFilesToSDEShop.Name = "toolStripMenuItemCopyFilesToSDEShop";
-            this.toolStripMenuItemCopyFilesToSDEShop.Size = new System.Drawing.Size(128, 22);
-            this.toolStripMenuItemCopyFilesToSDEShop.Text = "Copy files";
-            this.toolStripMenuItemCopyFilesToSDEShop.Click += new System.EventHandler(this.toolStripMenuItemCopyFilesToSDEShop_Click);
-            // 
-            // toolStripMenuItemMoveFilesToSDEShop
-            // 
-            this.toolStripMenuItemMoveFilesToSDEShop.Name = "toolStripMenuItemMoveFilesToSDEShop";
-            this.toolStripMenuItemMoveFilesToSDEShop.Size = new System.Drawing.Size(128, 22);
-            this.toolStripMenuItemMoveFilesToSDEShop.Text = "Move files";
-            this.toolStripMenuItemMoveFilesToSDEShop.Click += new System.EventHandler(this.toolStripMenuItemMoveFilesToSDEShop_Click);
-            // 
-            // toolStripMenuItem69
-            // 
-            this.toolStripMenuItem69.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemCopyFilesToFolderEShop,
-            this.toolStripMenuItemMoveFilesToFolderEShop});
-            this.toolStripMenuItem69.Name = "toolStripMenuItem69";
-            this.toolStripMenuItem69.Size = new System.Drawing.Size(116, 22);
-            this.toolStripMenuItem69.Text = "Folder...";
-            // 
-            // toolStripMenuItemCopyFilesToFolderEShop
-            // 
-            this.toolStripMenuItemCopyFilesToFolderEShop.Name = "toolStripMenuItemCopyFilesToFolderEShop";
-            this.toolStripMenuItemCopyFilesToFolderEShop.Size = new System.Drawing.Size(128, 22);
-            this.toolStripMenuItemCopyFilesToFolderEShop.Text = "Copy files";
-            this.toolStripMenuItemCopyFilesToFolderEShop.Click += new System.EventHandler(this.toolStripMenuItemCopyFilesToFolderEShop_Click);
-            // 
-            // toolStripMenuItemMoveFilesToFolderEShop
-            // 
-            this.toolStripMenuItemMoveFilesToFolderEShop.Name = "toolStripMenuItemMoveFilesToFolderEShop";
-            this.toolStripMenuItemMoveFilesToFolderEShop.Size = new System.Drawing.Size(128, 22);
-            this.toolStripMenuItemMoveFilesToFolderEShop.Text = "Move files";
-            this.toolStripMenuItemMoveFilesToFolderEShop.Click += new System.EventHandler(this.toolStripMenuItemMoveFilesToFolderEShop_Click);
-            // 
-            // tabPage5
-            // 
-            this.tabPage5.Controls.Add(this.panel6);
-            this.tabPage5.Controls.Add(this.panel7);
-            this.tabPage5.Location = new System.Drawing.Point(4, 22);
-            this.tabPage5.Name = "tabPage5";
-            this.tabPage5.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage5.Size = new System.Drawing.Size(1517, 366);
-            this.tabPage5.TabIndex = 4;
-            this.tabPage5.Text = "Log";
-            this.tabPage5.UseVisualStyleBackColor = true;
+            // tabPageLog
+            // 
+            this.tabPageLog.Controls.Add(this.panel6);
+            this.tabPageLog.Controls.Add(this.panel7);
+            this.tabPageLog.Location = new System.Drawing.Point(4, 22);
+            this.tabPageLog.Name = "tabPageLog";
+            this.tabPageLog.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPageLog.Size = new System.Drawing.Size(1517, 366);
+            this.tabPageLog.TabIndex = 4;
+            this.tabPageLog.Text = "Log";
+            this.tabPageLog.UseVisualStyleBackColor = true;
             // 
             // panel6
             // 
@@ -3775,9 +3777,10 @@
             this.toolStripStatusFilesOperation,
             this.toolStripProgressAddingFiles,
             this.toolStripStatusLabelGame,
-            this.toolStripStatusLabel3,
-            this.toolStripStatusLabel4,
-            this.toolStripStatusLabel5});
+            this.toolStripStatusLabelFilesInXCI,
+            this.toolStripStatusLabelFilesInNSP,
+            this.toolStripStatusLabelFilesInBoth,
+            this.toolStripStatusLabelVersion});
             this.statusStrip1.Location = new System.Drawing.Point(0, 418);
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.Size = new System.Drawing.Size(1527, 49);
@@ -3825,26 +3828,32 @@
             this.toolStripStatusLabelGame.Text = "game aaa";
             this.toolStripStatusLabelGame.Visible = false;
             // 
-            // toolStripStatusLabel3
+            // toolStripStatusLabelFilesInXCI
             // 
-            this.toolStripStatusLabel3.Name = "toolStripStatusLabel3";
-            this.toolStripStatusLabel3.Size = new System.Drawing.Size(86, 44);
-            this.toolStripStatusLabel3.Text = "Files on XCI list";
-            this.toolStripStatusLabel3.Visible = false;
+            this.toolStripStatusLabelFilesInXCI.Name = "toolStripStatusLabelFilesInXCI";
+            this.toolStripStatusLabelFilesInXCI.Size = new System.Drawing.Size(82, 44);
+            this.toolStripStatusLabelFilesInXCI.Text = "Files in XCI list";
+            this.toolStripStatusLabelFilesInXCI.Visible = false;
             // 
-            // toolStripStatusLabel4
+            // toolStripStatusLabelFilesInNSP
             // 
-            this.toolStripStatusLabel4.Name = "toolStripStatusLabel4";
-            this.toolStripStatusLabel4.Size = new System.Drawing.Size(105, 44);
-            this.toolStripStatusLabel4.Text = "Files on E-shop list";
-            this.toolStripStatusLabel4.Visible = false;
+            this.toolStripStatusLabelFilesInNSP.Name = "toolStripStatusLabelFilesInNSP";
+            this.toolStripStatusLabelFilesInNSP.Size = new System.Drawing.Size(86, 44);
+            this.toolStripStatusLabelFilesInNSP.Text = "Files in NSP list";
+            this.toolStripStatusLabelFilesInNSP.Visible = false;
             // 
-            // toolStripStatusLabel5
+            // toolStripStatusLabelFilesInBoth
             // 
-            this.toolStripStatusLabel5.Name = "toolStripStatusLabel5";
-            this.toolStripStatusLabel5.Size = new System.Drawing.Size(180, 44);
-            this.toolStripStatusLabel5.Text = "Files on Both lists (XCI && E-shop)";
-            this.toolStripStatusLabel5.Visible = false;
+            this.toolStripStatusLabelFilesInBoth.Name = "toolStripStatusLabelFilesInBoth";
+            this.toolStripStatusLabelFilesInBoth.Size = new System.Drawing.Size(161, 44);
+            this.toolStripStatusLabelFilesInBoth.Text = "Files in both lists (XCI && NSP)";
+            this.toolStripStatusLabelFilesInBoth.Visible = false;
+            // 
+            // toolStripStatusLabelVersion
+            // 
+            this.toolStripStatusLabelVersion.Name = "toolStripStatusLabelVersion";
+            this.toolStripStatusLabelVersion.Size = new System.Drawing.Size(137, 44);
+            this.toolStripStatusLabelVersion.Text = "Version Update Available";
             // 
             // menuStrip1
             // 
@@ -3903,37 +3912,37 @@
             // updateLocalDatabaseToolStripMenuItem
             // 
             this.updateLocalDatabaseToolStripMenuItem.Name = "updateLocalDatabaseToolStripMenuItem";
-            this.updateLocalDatabaseToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.updateLocalDatabaseToolStripMenuItem.Size = new System.Drawing.Size(238, 22);
             this.updateLocalDatabaseToolStripMenuItem.Text = "&Update local database";
             this.updateLocalDatabaseToolStripMenuItem.Click += new System.EventHandler(this.updateLocalDatabaseToolStripMenuItem_Click);
             // 
             // updateEshopLocalDatabaseToolStripMenuItem
             // 
             this.updateEshopLocalDatabaseToolStripMenuItem.Name = "updateEshopLocalDatabaseToolStripMenuItem";
-            this.updateEshopLocalDatabaseToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
-            this.updateEshopLocalDatabaseToolStripMenuItem.Text = "Update e-shop local database";
+            this.updateEshopLocalDatabaseToolStripMenuItem.Size = new System.Drawing.Size(238, 22);
+            this.updateEshopLocalDatabaseToolStripMenuItem.Text = "Update eShop local database";
             this.updateEshopLocalDatabaseToolStripMenuItem.Visible = false;
             this.updateEshopLocalDatabaseToolStripMenuItem.Click += new System.EventHandler(this.updateEshopLocalDatabaseToolStripMenuItem_Click);
             // 
             // updateNswdbcomListToolStripMenuItem1
             // 
             this.updateNswdbcomListToolStripMenuItem1.Name = "updateNswdbcomListToolStripMenuItem1";
-            this.updateNswdbcomListToolStripMenuItem1.Size = new System.Drawing.Size(232, 22);
+            this.updateNswdbcomListToolStripMenuItem1.Size = new System.Drawing.Size(238, 22);
             this.updateNswdbcomListToolStripMenuItem1.Text = "Update nswdb.com list";
             this.updateNswdbcomListToolStripMenuItem1.Click += new System.EventHandler(this.updateNswdbcomListToolStripMenuItem1_Click);
             // 
             // updateVersionListToolStripMenuItem
             // 
             this.updateVersionListToolStripMenuItem.Name = "updateVersionListToolStripMenuItem";
-            this.updateVersionListToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.updateVersionListToolStripMenuItem.Size = new System.Drawing.Size(238, 22);
             this.updateVersionListToolStripMenuItem.Text = "Update version list";
             this.updateVersionListToolStripMenuItem.Click += new System.EventHandler(this.updateVersionListToolStripMenuItem_Click);
             // 
             // scrapExtendedInfoFromWebToolStripMenuItem
             // 
             this.scrapExtendedInfoFromWebToolStripMenuItem.Name = "scrapExtendedInfoFromWebToolStripMenuItem";
-            this.scrapExtendedInfoFromWebToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
-            this.scrapExtendedInfoFromWebToolStripMenuItem.Text = "Scrap extended info from web";
+            this.scrapExtendedInfoFromWebToolStripMenuItem.Size = new System.Drawing.Size(238, 22);
+            this.scrapExtendedInfoFromWebToolStripMenuItem.Text = "Scrape extended info from web";
             this.scrapExtendedInfoFromWebToolStripMenuItem.Click += new System.EventHandler(this.scrapExtendedInfoFromWebToolStripMenuItem_Click);
             // 
             // viewToolStripMenuItem
@@ -4254,7 +4263,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).EndInit();
             this.splitContainer2.ResumeLayout(false);
             this.tabControl1.ResumeLayout(false);
-            this.tabPage1.ResumeLayout(false);
+            this.tabPageXCI.ResumeLayout(false);
             this.panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.OLVLocalFiles)).EndInit();
             this.contextMenuLocalList.ResumeLayout(false);
@@ -4265,22 +4274,7 @@
             this.panel8.PerformLayout();
             this.menuLocalFiles.ResumeLayout(false);
             this.menuLocalFiles.PerformLayout();
-            this.tabPage2.ResumeLayout(false);
-            this.tabPage2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.OLV_SDCard)).EndInit();
-            this.contextMenuStripSDCard.ResumeLayout(false);
-            this.panel5.ResumeLayout(false);
-            this.panel5.PerformLayout();
-            this.menuSDFiles.ResumeLayout(false);
-            this.menuSDFiles.PerformLayout();
-            this.tabPage3.ResumeLayout(false);
-            this.panel4.ResumeLayout(false);
-            this.panel4.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.OLVSceneList)).EndInit();
-            this.contextMenuStripScene.ResumeLayout(false);
-            this.menuStrip3.ResumeLayout(false);
-            this.menuStrip3.PerformLayout();
-            this.tabPage4.ResumeLayout(false);
+            this.tabPageNSP.ResumeLayout(false);
             this.panel10.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.OLVEshop)).EndInit();
             this.contextMenuEShopList.ResumeLayout(false);
@@ -4291,7 +4285,22 @@
             this.panel12.PerformLayout();
             this.menuEShop.ResumeLayout(false);
             this.menuEShop.PerformLayout();
-            this.tabPage5.ResumeLayout(false);
+            this.tabPageSD.ResumeLayout(false);
+            this.tabPageSD.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.OLV_SDCard)).EndInit();
+            this.contextMenuStripSDCard.ResumeLayout(false);
+            this.panel5.ResumeLayout(false);
+            this.panel5.PerformLayout();
+            this.menuSDFiles.ResumeLayout(false);
+            this.menuSDFiles.PerformLayout();
+            this.tabPageScene.ResumeLayout(false);
+            this.panel4.ResumeLayout(false);
+            this.panel4.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.OLVSceneList)).EndInit();
+            this.contextMenuStripScene.ResumeLayout(false);
+            this.menuStrip3.ResumeLayout(false);
+            this.menuStrip3.PerformLayout();
+            this.tabPageLog.ResumeLayout(false);
             this.panel6.ResumeLayout(false);
             this.panel7.ResumeLayout(false);
             this.statusStrip1.ResumeLayout(false);
@@ -4332,9 +4341,9 @@
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel1;
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel2;
         private System.Windows.Forms.TabControl tabControl1;
-        private System.Windows.Forms.TabPage tabPage1;
-        private System.Windows.Forms.TabPage tabPage2;
-        private System.Windows.Forms.TabPage tabPage3;
+        private System.Windows.Forms.TabPage tabPageXCI;
+        private System.Windows.Forms.TabPage tabPageSD;
+        private System.Windows.Forms.TabPage tabPageScene;
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.Panel panel2;
         private System.Windows.Forms.Panel panel3;
@@ -4528,7 +4537,7 @@
         private System.Windows.Forms.TextBox textBoxFilterScene;
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.ComboBox cbxFilterScene;
-        private System.Windows.Forms.TabPage tabPage4;
+        private System.Windows.Forms.TabPage tabPageNSP;
         private System.Windows.Forms.ContextMenuStrip contextMenuEShopList;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemEShopShowInExplorer;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator9;
@@ -4554,7 +4563,7 @@
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemEShopUpdateInfo;
         private System.ComponentModel.BackgroundWorker backgroundWorkerUpdateFiles;
         private BrightIdeasSoftware.OLVColumn olvColumnTitleIDLocal;
-        private System.Windows.Forms.TabPage tabPage5;
+        private System.Windows.Forms.TabPage tabPageLog;
         private System.Windows.Forms.Panel panel7;
         private System.Windows.Forms.Button btnClearLogFile;
         private System.Windows.Forms.Panel panel6;
@@ -4735,9 +4744,10 @@
         private System.Windows.Forms.CheckBox cbUpdates;
         private System.Windows.Forms.CheckBox cbDLC;
         private BrightIdeasSoftware.OLVColumn olvColumnContentTypeEShop;
-        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel3;
-        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel4;
-        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel5;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelFilesInXCI;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelFilesInNSP;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelFilesInBoth;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelVersion;
         private BrightIdeasSoftware.OLVColumn olvColumnImportedDateLocal;
         private BrightIdeasSoftware.OLVColumn olvColumnImportedDateEShop;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem97Eshop;

--- a/Switch Backup Manager/Form1.cs
+++ b/Switch Backup Manager/Form1.cs
@@ -515,34 +515,24 @@ namespace Switch_Backup_Manager
                 {
                     case "WLD":
                         return Properties.Resources.WLD;
-                    //break;
                     case "USA":
                         return Properties.Resources.USA;
-                    //break;
                     case "JPN":
                         return Properties.Resources.JPN;
-                    //break;
                     case "EUR":
                         return Properties.Resources.EUR;
-                    //break;
                     case "CHN":
                         return Properties.Resources.CHN;
-                    //break;
                     case "GER":
                         return Properties.Resources.GER;
-                    //break;
                     case "KOR":
                         return Properties.Resources.KOR;
-                    //break;
                     case "SPA":
                         return Properties.Resources.SPA;
-                    //break;
                     case "UKV":
                         return Properties.Resources.UKV;
-                    //break;
                     default:
                         return Properties.Resources.WLD;
-                        //break;
                 }
             };
 
@@ -1124,39 +1114,52 @@ namespace Switch_Backup_Manager
             toolStripStatusLabel1.Text = "0 Selected (0MB)";
 
             panelEditTitle.Visible = false;
-            toolStripStatusLabel3.Visible = false;
-            toolStripStatusLabel4.Visible = false;
-            toolStripStatusLabel5.Visible = false;
+            toolStripStatusLabelFilesInXCI.Visible = false;
+            toolStripStatusLabelFilesInNSP.Visible = false;
+            toolStripStatusLabelFilesInBoth.Visible = false;
+            toolStripStatusLabelVersion.Visible = false;
 
             switch (tabControl1.SelectedIndex)
             {
-                case 0: //Files
+                case 0: // XCI
+                    if (Util.HighlightVersionOnXCI)
+                    {
+                        toolStripStatusLabelVersion.BackColor = Util.HighlightVersion_color;
+                        toolStripStatusLabelVersion.Visible = true;
+                    }
+
                     SumarizeLocalGamesList("local");
                     break;
-                case 1: //SD Card
+                case 1: // NSP
+                    if (Util.HighlightVersionOnNSP)
+                    {
+                        toolStripStatusLabelVersion.BackColor = Util.HighlightVersion_color;
+                        toolStripStatusLabelVersion.Visible = true;
+                    }
+
+                    SumarizeLocalGamesList("eshop");
+                    break;
+                case 2: // SD Card
                     SumarizeLocalGamesList("sdcard");
                     break;
-                case 2: //Scene
+                case 3: // Scene
                     if (Util.HighlightXCIOnScene)
                     {
-                        toolStripStatusLabel3.BackColor = Util.HighlightXCIOnScene_color;
-                        toolStripStatusLabel3.Visible = true;
+                        toolStripStatusLabelFilesInXCI.BackColor = Util.HighlightXCIOnScene_color;
+                        toolStripStatusLabelFilesInXCI.Visible = true;
                     }
                     if (Util.HighlightNSPOnScene)
                     {
-                        toolStripStatusLabel4.BackColor = Util.HighlightNSPOnScene_color;
-                        toolStripStatusLabel4.Visible = true;
+                        toolStripStatusLabelFilesInNSP.BackColor = Util.HighlightNSPOnScene_color;
+                        toolStripStatusLabelFilesInNSP.Visible = true;
                     }
                     if (Util.HighlightBothOnScene)
                     {
-                        toolStripStatusLabel5.BackColor = Util.HighlightBothOnScene_color;
-                        toolStripStatusLabel5.Visible = true;
+                        toolStripStatusLabelFilesInBoth.BackColor = Util.HighlightBothOnScene_color;
+                        toolStripStatusLabelFilesInBoth.Visible = true;
                     }
 
                     SumarizeLocalGamesList("scene");
-                    break;
-                case 3: //Eshop
-                    SumarizeLocalGamesList("eshop");
                     break;
             }
         }
@@ -1413,7 +1416,7 @@ namespace Switch_Backup_Manager
                 }
 
 
-                //                UpdateSDCardList();
+                // UpdateSDCardList();
             }
             else
             {
@@ -1771,7 +1774,7 @@ namespace Switch_Backup_Manager
 
         private void objectListView1_FormatCell(object sender, BrightIdeasSoftware.FormatCellEventArgs e)
         {
-            //Highlights when not trimmed
+            // Highlights when not trimmed
             if (e.ColumnIndex == this.olvColumnIsTrimmedLocal.Index)
             {
                 FileData data = (FileData)e.Model;
@@ -1784,6 +1787,11 @@ namespace Switch_Backup_Manager
                 if (data.Source.Contains("NSP") || data.Source.Contains("NCA"))
                     e.SubItem.BackColor = Color.IndianRed;
             }
+
+            // Highlights when potential version update is available
+            // TODO: Toggle - Highlight only if latest version NSP isn't somewhere in the NSP list
+            if (Util.HighlightVersionOnXCI && (e.ColumnIndex == this.olvColumnVersionLocal.Index || e.ColumnIndex == this.olvColumnLatestLocal.Index))
+                highlightVersionUpdate(e);
         }
 
         private void OLVSceneList_FormatCell(object sender, BrightIdeasSoftware.FormatCellEventArgs e)
@@ -3874,6 +3882,11 @@ namespace Switch_Backup_Manager
                 if (data.Source.Contains("XCI") || data.Source.Contains("NCA"))
                     e.SubItem.BackColor = Color.IndianRed;
             }
+
+            // Highlights when potential version update is available
+            // TODO: Highlight only if latest version NSP isn't somewhere in the list
+            if (Util.HighlightVersionOnNSP && (e.ColumnIndex == this.olvColumnVersionEShop.Index || e.ColumnIndex == this.olvColumnLatestEShop.Index))
+                highlightVersionUpdate(e);
         }
 
         private void richTextBoxLog_TextChanged(object sender, EventArgs e)
@@ -4200,54 +4213,54 @@ namespace Switch_Backup_Manager
                 }
             }
 
-            int index = 0;
-            string titleID = updates.ElementAt(0).Value.TitleID;
-            int version = -1;
-            try
+            if (updates.Count > 0)
             {
-                version = Convert.ToInt32(updates.ElementAt(0).Value.Version);
-            }
-            catch
-            {
-                Util.logger.Error("Error on " + titleID + ", " + updates.ElementAt(0).Value.Version);
-            }
+                int index = 0;
+                string titleID = updates.ElementAt(0).Value.TitleID;
+                int version = -1;
 
-            foreach (FileData file in updates.Values)
-            {
-                if (index <= updates.Count - 2)
-                {
-                    updates_to_delete.Add(new Tuple<string, int>(file.TitleID, Convert.ToInt32(file.Version)), "");
-                }
-
-                if (file.TitleID != titleID)
-                {
-                    updates_to_delete.Remove(new Tuple<string, int>(titleID, Convert.ToInt32(version)));
-                }
-
-                titleID = updates.ElementAt(index).Value.TitleID;
-                version = Convert.ToInt32(updates.ElementAt(index).Value.Version);
-                index++;
-            }
-
-            OLVEshop.Select();
-            OLVEshop.HideSelection = false;
-            OLVEshop.SelectedItems.Clear();
-            foreach (ListViewItem item in OLVEshop.Items)
-            {
-                string dummy;
                 try
                 {
-                    if (updates_to_delete.TryGetValue(new Tuple<string, int>(item.Text, Convert.ToInt32(Convert.ToString(((FileData)((OLVListItem)item).RowObject).Version))), out dummy))
-                    {
-                        item.Selected = true;
-                    }
+                    version = Convert.ToInt32(updates.ElementAt(0).Value.Version);
                 }
                 catch
                 {
-                    //Util.logger.Error("Error on " + item.Text + ", " + Convert.ToString(((FileData)((OLVListItem)item).RowObject).Version));
+                    Util.logger.Error("Error on " + titleID + ", " + updates.ElementAt(0).Value.Version);
+                }
+
+                foreach (FileData file in updates.Values)
+                {
+                    if (index <= updates.Count - 2)
+                    {
+                        updates_to_delete.Add(new Tuple<string, int>(file.TitleID, Convert.ToInt32(file.Version)), "");
+                    }
+
+                    if (file.TitleID != titleID)
+                    {
+                        updates_to_delete.Remove(new Tuple<string, int>(titleID, Convert.ToInt32(version)));
+                    }
+
+                    titleID = updates.ElementAt(index).Value.TitleID;
+                    version = Convert.ToInt32(updates.ElementAt(index).Value.Version);
+                    index++;
+                }
+
+                OLVEshop.Select();
+                OLVEshop.HideSelection = false;
+                OLVEshop.SelectedItems.Clear();
+                foreach (ListViewItem item in OLVEshop.Items)
+                {
+                    string dummy;
+                    try
+                    {
+                        if (updates_to_delete.TryGetValue(new Tuple<string, int>(item.Text, Convert.ToInt32(Convert.ToString(((FileData)((OLVListItem)item).RowObject).Version))), out dummy))
+                        {
+                            item.Selected = true;
+                        }
+                    }
+                    catch { }
                 }
             }
-            //            OLVEshop.RefreshSelectedObjects();
         }
 
         private void toolStripMenuItemSelectSceneOnEShop_Click(object sender, EventArgs e)
@@ -4258,7 +4271,7 @@ namespace Switch_Backup_Manager
         private void itemsOnEshjToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Dictionary<Tuple<string, string>, FileData> list = ContainsListsIgnoreVersion(LocalNSPFilesList, LocalFilesList);
-            //            Dictionary<Tuple<string, string>, FileData> list = ContainsListsIgnoreVersion(LocalFilesList, LocalNSPFilesList);
+            // Dictionary<Tuple<string, string>, FileData> list = ContainsListsIgnoreVersion(LocalFilesList, LocalNSPFilesList);
             FileData dummy;
             OLVLocalFiles.Select();
             OLVLocalFiles.HideSelection = false;
@@ -4360,6 +4373,15 @@ namespace Switch_Backup_Manager
             string source = (string)parameters[2];
 
             Util.SplitXCIFiles(filesList, destinyPath, source);
+        }
+
+        private void highlightVersionUpdate(FormatCellEventArgs e)
+        {
+            FileData data = (FileData)e.Model;
+            int version, latest;
+            if (Int32.TryParse(data.Version, out version) && Int32.TryParse(data.Latest, out latest))
+                if (version >= 0 && version < latest)
+                    e.SubItem.BackColor = Util.HighlightVersion_color;
         }
     }
 }

--- a/Switch Backup Manager/Form1.cs
+++ b/Switch Backup Manager/Form1.cs
@@ -1775,7 +1775,7 @@ namespace Switch_Backup_Manager
         private void objectListView1_FormatCell(object sender, BrightIdeasSoftware.FormatCellEventArgs e)
         {
             FileData data = (FileData)e.Model;
-            
+
             // Highlights when not trimmed
             if (e.ColumnIndex == this.olvColumnIsTrimmedLocal.Index)
             {

--- a/Switch Backup Manager/Form1.resx
+++ b/Switch Backup Manager/Form1.resx
@@ -59,10 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" 
-    xmlns="" 
-    xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
-    xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -126,6 +123,12 @@
   <metadata name="menuLocalFiles.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>1155, 56</value>
   </metadata>
+  <metadata name="contextMenuEShopList.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>248, 56</value>
+  </metadata>
+  <metadata name="menuEShop.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1289, 56</value>
+  </metadata>
   <metadata name="contextMenuStripSDCard.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>1708, 17</value>
   </metadata>
@@ -137,12 +140,6 @@
   </metadata>
   <metadata name="menuStrip3.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>653, 17</value>
-  </metadata>
-  <metadata name="contextMenuEShopList.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>248, 56</value>
-  </metadata>
-  <metadata name="menuEShop.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1289, 56</value>
   </metadata>
   <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
@@ -179,6 +176,9 @@
   </metadata>
   <metadata name="backgroundWorkerSplitFiles.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>1705, 56</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>94</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -579,7 +579,8 @@
         gCn7nvhd8QgAWHtYUAKmWGi+hnTm+n4/VsS3JvarGcyTuRhN/K74BEDXi4PgSdpL47Sat5ErHPJdmsh2
         1bAnU3AshVnIxHDid8UvALq6QQBQsceAKarPHmRv6h1kggnf5Ymcyzz2sTzmsUKMJ/1a8Q2AtV4cBr8D
         THHm9CHGU79IkN/nuzwZXXPYZxexD+8ncQIgPyQTv2s4AmCtF4fBfcAUKytJTp24jHzx58nm1B1sZM+e
-        lushxmDB92a6VMfOVbFfP4R5OoFZnsCUDY2hmfDrGd8FDFT3BCLAYivNc6dKtJcuZv/Fr9I6AwCmmTRH XQ5gCUoL2Eoak/a9sf1oYBs/wf7TOPzkAGYmhekG21Dt4bfy/wFrZrfJnf5dvAAAAABJRU5ErkJggg==
-    </value>
+        lushxmDB92a6VMfOVbFfP4R5OoFZnsCUDY2hmfDrGd8FDFT3BCLAYivNc6dKtJcuZv/Fr9I6AwCmmTRH
+        XQ5gCUoL2Eoak/a9sf1oYBs/wf7TOPzkAGYmhekG21Dt4bfy/wFrZrfJnf5dvAAAAABJRU5ErkJggg==
+</value>
   </data>
 </root>

--- a/Switch Backup Manager/Form1.resx
+++ b/Switch Backup Manager/Form1.resx
@@ -59,7 +59,10 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema id="root" 
+    xmlns="" 
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -579,8 +582,7 @@
         gCn7nvhd8QgAWHtYUAKmWGi+hnTm+n4/VsS3JvarGcyTuRhN/K74BEDXi4PgSdpL47Sat5ErHPJdmsh2
         1bAnU3AshVnIxHDid8UvALq6QQBQsceAKarPHmRv6h1kggnf5Ymcyzz2sTzmsUKMJ/1a8Q2AtV4cBr8D
         THHm9CHGU79IkN/nuzwZXXPYZxexD+8ncQIgPyQTv2s4AmCtF4fBfcAUKytJTp24jHzx58nm1B1sZM+e
-        lushxmDB92a6VMfOVbFfP4R5OoFZnsCUDY2hmfDrGd8FDFT3BCLAYivNc6dKtJcuZv/Fr9I6AwCmmTRH
-        XQ5gCUoL2Eoak/a9sf1oYBs/wf7TOPzkAGYmhekG21Dt4bfy/wFrZrfJnf5dvAAAAABJRU5ErkJggg==
-</value>
+        lushxmDB92a6VMfOVbFfP4R5OoFZnsCUDY2hmfDrGd8FDFT3BCLAYivNc6dKtJcuZv/Fr9I6AwCmmTRH XQ5gCUoL2Eoak/a9sf1oYBs/wf7TOPzkAGYmhekG21Dt4bfy/wFrZrfJnf5dvAAAAABJRU5ErkJggg==
+    </value>
   </data>
 </root>

--- a/Switch Backup Manager/FormConfigs.Designer.cs
+++ b/Switch Backup Manager/FormConfigs.Designer.cs
@@ -52,7 +52,7 @@
             this.cbScrapXCIOnSD = new System.Windows.Forms.CheckBox();
             this.tabPage2 = new System.Windows.Forms.TabPage();
             this.versionHighlightsGroup = new System.Windows.Forms.GroupBox();
-            this.labelVersionsWithUpdate = new System.Windows.Forms.Label();
+            this.cbHighlightMissingNSPUpdate = new System.Windows.Forms.CheckBox();
             this.btnColorVersion = new System.Windows.Forms.Button();
             this.cbHighlightVersionOnNSP = new System.Windows.Forms.CheckBox();
             this.cbHighlightVersionOnXCI = new System.Windows.Forms.CheckBox();
@@ -144,7 +144,7 @@
             this.btnCancel.Location = new System.Drawing.Point(447, 6);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
-            this.btnCancel.TabIndex = 10;
+            this.btnCancel.TabIndex = 13;
             this.btnCancel.Text = "&Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
@@ -154,7 +154,7 @@
             this.btnOK.Location = new System.Drawing.Point(364, 6);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(75, 23);
-            this.btnOK.TabIndex = 9;
+            this.btnOK.TabIndex = 12;
             this.btnOK.Text = "&OK";
             this.btnOK.UseVisualStyleBackColor = true;
             this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
@@ -245,7 +245,7 @@
             this.cbScrapExtraInfoFromWeb.AutoSize = true;
             this.cbScrapExtraInfoFromWeb.Location = new System.Drawing.Point(10, 323);
             this.cbScrapExtraInfoFromWeb.Name = "cbScrapExtraInfoFromWeb";
-            this.cbScrapExtraInfoFromWeb.Size = new System.Drawing.Size(300, 17);
+            this.cbScrapExtraInfoFromWeb.Size = new System.Drawing.Size(306, 17);
             this.cbScrapExtraInfoFromWeb.TabIndex = 5;
             this.cbScrapExtraInfoFromWeb.Text = "Scrape extra info from web when new files are added (slow)";
             this.cbScrapExtraInfoFromWeb.UseVisualStyleBackColor = true;
@@ -371,7 +371,7 @@
             // 
             // versionHighlightsGroup
             // 
-            this.versionHighlightsGroup.Controls.Add(this.labelVersionsWithUpdate);
+            this.versionHighlightsGroup.Controls.Add(this.cbHighlightMissingNSPUpdate);
             this.versionHighlightsGroup.Controls.Add(this.btnColorVersion);
             this.versionHighlightsGroup.Controls.Add(this.cbHighlightVersionOnNSP);
             this.versionHighlightsGroup.Controls.Add(this.cbHighlightVersionOnXCI);
@@ -380,46 +380,49 @@
             this.versionHighlightsGroup.Size = new System.Drawing.Size(290, 100);
             this.versionHighlightsGroup.TabIndex = 6;
             this.versionHighlightsGroup.TabStop = false;
-            this.versionHighlightsGroup.Text = "Game Version Highlights";
+            this.versionHighlightsGroup.Text = "Version Update Highlights";
             // 
-            // labelVersionsWithUpdate
+            // cbHighlightMissingNSPUpdate
             // 
-            this.labelVersionsWithUpdate.AutoSize = true;
-            this.labelVersionsWithUpdate.Location = new System.Drawing.Point(14, 25);
-            this.labelVersionsWithUpdate.Name = "labelVersionsWithUpdate";
-            this.labelVersionsWithUpdate.Size = new System.Drawing.Size(108, 13);
-            this.labelVersionsWithUpdate.TabIndex = 0;
-            this.labelVersionsWithUpdate.Text = "Versions with update:";
+            this.cbHighlightMissingNSPUpdate.AutoSize = true;
+            this.cbHighlightMissingNSPUpdate.Enabled = false;
+            this.cbHighlightMissingNSPUpdate.Location = new System.Drawing.Point(36, 48);
+            this.cbHighlightMissingNSPUpdate.Name = "cbHighlightMissingNSPUpdate";
+            this.cbHighlightMissingNSPUpdate.Size = new System.Drawing.Size(163, 17);
+            this.cbHighlightMissingNSPUpdate.TabIndex = 7;
+            this.cbHighlightMissingNSPUpdate.Text = "Only if update isn\'t in NSP list";
+            this.cbHighlightMissingNSPUpdate.UseVisualStyleBackColor = true;
             // 
             // btnColorVersion
             // 
             this.btnColorVersion.BackColor = System.Drawing.Color.LightPink;
-            this.btnColorVersion.Location = new System.Drawing.Point(150, 20);
+            this.btnColorVersion.Location = new System.Drawing.Point(218, 20);
             this.btnColorVersion.Name = "btnColorVersion";
             this.btnColorVersion.Size = new System.Drawing.Size(24, 24);
-            this.btnColorVersion.TabIndex = 8;
+            this.btnColorVersion.TabIndex = 9;
             this.btnColorVersion.UseVisualStyleBackColor = false;
             this.btnColorVersion.Click += new System.EventHandler(this.btnColorVersion_Click);
             // 
             // cbHighlightVersionOnNSP
             // 
             this.cbHighlightVersionOnNSP.AutoSize = true;
-            this.cbHighlightVersionOnNSP.Location = new System.Drawing.Point(28, 71);
+            this.cbHighlightVersionOnNSP.Location = new System.Drawing.Point(17, 71);
             this.cbHighlightVersionOnNSP.Name = "cbHighlightVersionOnNSP";
-            this.cbHighlightVersionOnNSP.Size = new System.Drawing.Size(75, 17);
-            this.cbHighlightVersionOnNSP.TabIndex = 7;
-            this.cbHighlightVersionOnNSP.Text = "In NSP list";
+            this.cbHighlightVersionOnNSP.Size = new System.Drawing.Size(110, 17);
+            this.cbHighlightVersionOnNSP.TabIndex = 8;
+            this.cbHighlightVersionOnNSP.Text = "Games in NSP list";
             this.cbHighlightVersionOnNSP.UseVisualStyleBackColor = true;
             // 
             // cbHighlightVersionOnXCI
             // 
             this.cbHighlightVersionOnXCI.AutoSize = true;
-            this.cbHighlightVersionOnXCI.Location = new System.Drawing.Point(28, 48);
+            this.cbHighlightVersionOnXCI.Location = new System.Drawing.Point(17, 25);
             this.cbHighlightVersionOnXCI.Name = "cbHighlightVersionOnXCI";
-            this.cbHighlightVersionOnXCI.Size = new System.Drawing.Size(70, 17);
+            this.cbHighlightVersionOnXCI.Size = new System.Drawing.Size(105, 17);
             this.cbHighlightVersionOnXCI.TabIndex = 6;
-            this.cbHighlightVersionOnXCI.Text = "In XCI list";
+            this.cbHighlightVersionOnXCI.Text = "Games in XCI list";
             this.cbHighlightVersionOnXCI.UseVisualStyleBackColor = true;
+            this.cbHighlightVersionOnXCI.CheckedChanged += new System.EventHandler(this.cbHighlightVersionOnXCI_CheckedChanged);
             // 
             // labelRequiresRestart
             // 
@@ -508,10 +511,10 @@
             // cbShowCompletePaths
             // 
             this.cbShowCompletePaths.AutoSize = true;
-            this.cbShowCompletePaths.Location = new System.Drawing.Point(10, 135);
+            this.cbShowCompletePaths.Location = new System.Drawing.Point(10, 134);
             this.cbShowCompletePaths.Name = "cbShowCompletePaths";
             this.cbShowCompletePaths.Size = new System.Drawing.Size(205, 17);
-            this.cbShowCompletePaths.TabIndex = 0;
+            this.cbShowCompletePaths.TabIndex = 10;
             this.cbShowCompletePaths.Text = "Show complete path of files in the lists";
             this.cbShowCompletePaths.UseVisualStyleBackColor = true;
             // 
@@ -1006,6 +1009,6 @@
         private System.Windows.Forms.Button btnColorVersion;
         private System.Windows.Forms.CheckBox cbHighlightVersionOnNSP;
         private System.Windows.Forms.CheckBox cbHighlightVersionOnXCI;
-        private System.Windows.Forms.Label labelVersionsWithUpdate;
+        private System.Windows.Forms.CheckBox cbHighlightMissingNSPUpdate;
     }
 }

--- a/Switch Backup Manager/FormConfigs.Designer.cs
+++ b/Switch Backup Manager/FormConfigs.Designer.cs
@@ -51,8 +51,13 @@
             this.cbScrapNSPOnSD = new System.Windows.Forms.CheckBox();
             this.cbScrapXCIOnSD = new System.Windows.Forms.CheckBox();
             this.tabPage2 = new System.Windows.Forms.TabPage();
-            this.label1 = new System.Windows.Forms.Label();
-            this.groupBox5 = new System.Windows.Forms.GroupBox();
+            this.versionHighlightsGroup = new System.Windows.Forms.GroupBox();
+            this.labelVersionsWithUpdate = new System.Windows.Forms.Label();
+            this.btnColorVersion = new System.Windows.Forms.Button();
+            this.cbHighlightVersionOnNSP = new System.Windows.Forms.CheckBox();
+            this.cbHighlightVersionOnXCI = new System.Windows.Forms.CheckBox();
+            this.labelRequiresRestart = new System.Windows.Forms.Label();
+            this.sceneHighlightsGroup = new System.Windows.Forms.GroupBox();
             this.btnColorBoth = new System.Windows.Forms.Button();
             this.btnColorEshop = new System.Windows.Forms.Button();
             this.btnColorXCI = new System.Windows.Forms.Button();
@@ -99,7 +104,8 @@
             this.groupBox3.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.tabPage2.SuspendLayout();
-            this.groupBox5.SuspendLayout();
+            this.versionHighlightsGroup.SuspendLayout();
+            this.sceneHighlightsGroup.SuspendLayout();
             this.tabPage3.SuspendLayout();
             this.tabControl2.SuspendLayout();
             this.tabPage4.SuspendLayout();
@@ -118,41 +124,37 @@
             this.panel1.Controls.Add(this.btnCancel);
             this.panel1.Controls.Add(this.btnOK);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel1.Location = new System.Drawing.Point(0, 674);
-            this.panel1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.panel1.Location = new System.Drawing.Point(0, 438);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(926, 55);
+            this.panel1.Size = new System.Drawing.Size(617, 36);
             this.panel1.TabIndex = 1;
             // 
             // btnApply
             // 
-            this.btnApply.Location = new System.Drawing.Point(795, 9);
-            this.btnApply.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.btnApply.Location = new System.Drawing.Point(530, 6);
             this.btnApply.Name = "btnApply";
-            this.btnApply.Size = new System.Drawing.Size(112, 35);
-            this.btnApply.TabIndex = 2;
+            this.btnApply.Size = new System.Drawing.Size(75, 23);
+            this.btnApply.TabIndex = 11;
             this.btnApply.Text = "&Apply";
             this.btnApply.UseVisualStyleBackColor = true;
             this.btnApply.Click += new System.EventHandler(this.btnApply_Click);
             // 
             // btnCancel
             // 
-            this.btnCancel.Location = new System.Drawing.Point(670, 9);
-            this.btnCancel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.btnCancel.Location = new System.Drawing.Point(447, 6);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(112, 35);
-            this.btnCancel.TabIndex = 1;
+            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.TabIndex = 10;
             this.btnCancel.Text = "&Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
             // 
             // btnOK
             // 
-            this.btnOK.Location = new System.Drawing.Point(546, 9);
-            this.btnOK.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.btnOK.Location = new System.Drawing.Point(364, 6);
             this.btnOK.Name = "btnOK";
-            this.btnOK.Size = new System.Drawing.Size(112, 35);
-            this.btnOK.TabIndex = 0;
+            this.btnOK.Size = new System.Drawing.Size(75, 23);
+            this.btnOK.TabIndex = 9;
             this.btnOK.Text = "&OK";
             this.btnOK.UseVisualStyleBackColor = true;
             this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
@@ -162,9 +164,8 @@
             this.panel2.Controls.Add(this.tabControl1);
             this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panel2.Location = new System.Drawing.Point(0, 0);
-            this.panel2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(926, 674);
+            this.panel2.Size = new System.Drawing.Size(617, 438);
             this.panel2.TabIndex = 2;
             // 
             // tabControl1
@@ -174,10 +175,9 @@
             this.tabControl1.Controls.Add(this.tabPage3);
             this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tabControl1.Location = new System.Drawing.Point(0, 0);
-            this.tabControl1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(926, 674);
+            this.tabControl1.Size = new System.Drawing.Size(617, 438);
             this.tabControl1.TabIndex = 1;
             // 
             // tabPage1
@@ -191,11 +191,10 @@
             this.tabPage1.Controls.Add(this.groupBox3);
             this.tabPage1.Controls.Add(this.cbAutoUpdateScene);
             this.tabPage1.Controls.Add(this.groupBox2);
-            this.tabPage1.Location = new System.Drawing.Point(4, 29);
-            this.tabPage1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.tabPage1.Location = new System.Drawing.Point(4, 22);
             this.tabPage1.Name = "tabPage1";
-            this.tabPage1.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.tabPage1.Size = new System.Drawing.Size(918, 641);
+            this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage1.Size = new System.Drawing.Size(609, 412);
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "General";
             this.tabPage1.UseVisualStyleBackColor = true;
@@ -203,19 +202,19 @@
             // labelLastVersionListUpdate
             // 
             this.labelLastVersionListUpdate.AutoSize = true;
-            this.labelLastVersionListUpdate.Location = new System.Drawing.Point(9, 585);
+            this.labelLastVersionListUpdate.Location = new System.Drawing.Point(6, 380);
+            this.labelLastVersionListUpdate.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.labelLastVersionListUpdate.Name = "labelLastVersionListUpdate";
-            this.labelLastVersionListUpdate.Size = new System.Drawing.Size(220, 20);
+            this.labelLastVersionListUpdate.Size = new System.Drawing.Size(150, 13);
             this.labelLastVersionListUpdate.TabIndex = 9;
             this.labelLastVersionListUpdate.Text = "Last version list update: Never";
             // 
             // cbSendDeletedFileToRecycleBin
             // 
             this.cbSendDeletedFileToRecycleBin.AutoSize = true;
-            this.cbSendDeletedFileToRecycleBin.Location = new System.Drawing.Point(308, 531);
-            this.cbSendDeletedFileToRecycleBin.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cbSendDeletedFileToRecycleBin.Location = new System.Drawing.Point(209, 345);
             this.cbSendDeletedFileToRecycleBin.Name = "cbSendDeletedFileToRecycleBin";
-            this.cbSendDeletedFileToRecycleBin.Size = new System.Drawing.Size(258, 24);
+            this.cbSendDeletedFileToRecycleBin.Size = new System.Drawing.Size(176, 17);
             this.cbSendDeletedFileToRecycleBin.TabIndex = 8;
             this.cbSendDeletedFileToRecycleBin.Text = "Send deleted files to recycle bin";
             this.cbSendDeletedFileToRecycleBin.UseVisualStyleBackColor = true;
@@ -223,10 +222,9 @@
             // cbUserCanDeleteFiles
             // 
             this.cbUserCanDeleteFiles.AutoSize = true;
-            this.cbUserCanDeleteFiles.Location = new System.Drawing.Point(9, 531);
-            this.cbUserCanDeleteFiles.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cbUserCanDeleteFiles.Location = new System.Drawing.Point(10, 345);
             this.cbUserCanDeleteFiles.Name = "cbUserCanDeleteFiles";
-            this.cbUserCanDeleteFiles.Size = new System.Drawing.Size(267, 24);
+            this.cbUserCanDeleteFiles.Size = new System.Drawing.Size(180, 17);
             this.cbUserCanDeleteFiles.TabIndex = 7;
             this.cbUserCanDeleteFiles.Text = "User can delete files (DANGER!)";
             this.cbUserCanDeleteFiles.UseVisualStyleBackColor = true;
@@ -235,10 +233,9 @@
             // cbAutoRemoveMissingFiles
             // 
             this.cbAutoRemoveMissingFiles.AutoSize = true;
-            this.cbAutoRemoveMissingFiles.Location = new System.Drawing.Point(9, 429);
-            this.cbAutoRemoveMissingFiles.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cbAutoRemoveMissingFiles.Location = new System.Drawing.Point(10, 279);
             this.cbAutoRemoveMissingFiles.Name = "cbAutoRemoveMissingFiles";
-            this.cbAutoRemoveMissingFiles.Size = new System.Drawing.Size(328, 24);
+            this.cbAutoRemoveMissingFiles.Size = new System.Drawing.Size(219, 17);
             this.cbAutoRemoveMissingFiles.TabIndex = 6;
             this.cbAutoRemoveMissingFiles.Text = "Automatic remove missing files on startup";
             this.cbAutoRemoveMissingFiles.UseVisualStyleBackColor = true;
@@ -246,21 +243,19 @@
             // cbScrapExtraInfoFromWeb
             // 
             this.cbScrapExtraInfoFromWeb.AutoSize = true;
-            this.cbScrapExtraInfoFromWeb.Location = new System.Drawing.Point(9, 497);
-            this.cbScrapExtraInfoFromWeb.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cbScrapExtraInfoFromWeb.Location = new System.Drawing.Point(10, 323);
             this.cbScrapExtraInfoFromWeb.Name = "cbScrapExtraInfoFromWeb";
-            this.cbScrapExtraInfoFromWeb.Size = new System.Drawing.Size(443, 24);
+            this.cbScrapExtraInfoFromWeb.Size = new System.Drawing.Size(300, 17);
             this.cbScrapExtraInfoFromWeb.TabIndex = 5;
-            this.cbScrapExtraInfoFromWeb.Text = "Scrap extra info from web when new files are added (slow)";
+            this.cbScrapExtraInfoFromWeb.Text = "Scrape extra info from web when new files are added (slow)";
             this.cbScrapExtraInfoFromWeb.UseVisualStyleBackColor = true;
             // 
             // cbUseTitleKeys
             // 
             this.cbUseTitleKeys.AutoSize = true;
-            this.cbUseTitleKeys.Location = new System.Drawing.Point(9, 463);
-            this.cbUseTitleKeys.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cbUseTitleKeys.Location = new System.Drawing.Point(10, 301);
             this.cbUseTitleKeys.Name = "cbUseTitleKeys";
-            this.cbUseTitleKeys.Size = new System.Drawing.Size(368, 24);
+            this.cbUseTitleKeys.Size = new System.Drawing.Size(248, 17);
             this.cbUseTitleKeys.TabIndex = 4;
             this.cbUseTitleKeys.Text = "Use titlekeys.txt to get missing info on NSP files";
             this.cbUseTitleKeys.UseVisualStyleBackColor = true;
@@ -270,11 +265,9 @@
             this.groupBox3.Controls.Add(this.btnRemFolderAutoScan);
             this.groupBox3.Controls.Add(this.btnAddFolderAutoScan);
             this.groupBox3.Controls.Add(this.checkedListBoxAutoScanFolders);
-            this.groupBox3.Location = new System.Drawing.Point(15, 189);
-            this.groupBox3.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox3.Location = new System.Drawing.Point(10, 123);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.groupBox3.Size = new System.Drawing.Size(882, 197);
+            this.groupBox3.Size = new System.Drawing.Size(588, 128);
             this.groupBox3.TabIndex = 3;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Folders to scan at startup";
@@ -282,10 +275,9 @@
             // btnRemFolderAutoScan
             // 
             this.btnRemFolderAutoScan.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnRemFolderAutoScan.Location = new System.Drawing.Point(825, 83);
-            this.btnRemFolderAutoScan.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.btnRemFolderAutoScan.Location = new System.Drawing.Point(550, 54);
             this.btnRemFolderAutoScan.Name = "btnRemFolderAutoScan";
-            this.btnRemFolderAutoScan.Size = new System.Drawing.Size(48, 43);
+            this.btnRemFolderAutoScan.Size = new System.Drawing.Size(32, 28);
             this.btnRemFolderAutoScan.TabIndex = 4;
             this.btnRemFolderAutoScan.Text = "-";
             this.btnRemFolderAutoScan.UseVisualStyleBackColor = true;
@@ -294,10 +286,9 @@
             // btnAddFolderAutoScan
             // 
             this.btnAddFolderAutoScan.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnAddFolderAutoScan.Location = new System.Drawing.Point(825, 31);
-            this.btnAddFolderAutoScan.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.btnAddFolderAutoScan.Location = new System.Drawing.Point(550, 20);
             this.btnAddFolderAutoScan.Name = "btnAddFolderAutoScan";
-            this.btnAddFolderAutoScan.Size = new System.Drawing.Size(48, 43);
+            this.btnAddFolderAutoScan.Size = new System.Drawing.Size(32, 28);
             this.btnAddFolderAutoScan.TabIndex = 3;
             this.btnAddFolderAutoScan.Text = "+";
             this.btnAddFolderAutoScan.UseVisualStyleBackColor = true;
@@ -306,19 +297,17 @@
             // checkedListBoxAutoScanFolders
             // 
             this.checkedListBoxAutoScanFolders.FormattingEnabled = true;
-            this.checkedListBoxAutoScanFolders.Location = new System.Drawing.Point(10, 31);
-            this.checkedListBoxAutoScanFolders.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.checkedListBoxAutoScanFolders.Location = new System.Drawing.Point(7, 20);
             this.checkedListBoxAutoScanFolders.Name = "checkedListBoxAutoScanFolders";
-            this.checkedListBoxAutoScanFolders.Size = new System.Drawing.Size(804, 130);
+            this.checkedListBoxAutoScanFolders.Size = new System.Drawing.Size(537, 94);
             this.checkedListBoxAutoScanFolders.TabIndex = 0;
             // 
             // cbAutoUpdateScene
             // 
             this.cbAutoUpdateScene.AutoSize = true;
-            this.cbAutoUpdateScene.Location = new System.Drawing.Point(9, 395);
-            this.cbAutoUpdateScene.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cbAutoUpdateScene.Location = new System.Drawing.Point(10, 257);
             this.cbAutoUpdateScene.Name = "cbAutoUpdateScene";
-            this.cbAutoUpdateScene.Size = new System.Drawing.Size(307, 24);
+            this.cbAutoUpdateScene.Size = new System.Drawing.Size(206, 17);
             this.cbAutoUpdateScene.TabIndex = 2;
             this.cbAutoUpdateScene.Text = "Automatic update scene list on startup";
             this.cbAutoUpdateScene.UseVisualStyleBackColor = true;
@@ -328,11 +317,9 @@
             this.groupBox2.Controls.Add(this.cbScrapLayerFSOnSD);
             this.groupBox2.Controls.Add(this.cbScrapNSPOnSD);
             this.groupBox2.Controls.Add(this.cbScrapXCIOnSD);
-            this.groupBox2.Location = new System.Drawing.Point(15, 26);
-            this.groupBox2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox2.Location = new System.Drawing.Point(10, 17);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.groupBox2.Size = new System.Drawing.Size(882, 154);
+            this.groupBox2.Size = new System.Drawing.Size(588, 100);
             this.groupBox2.TabIndex = 1;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Show on SD card";
@@ -341,84 +328,129 @@
             // 
             this.cbScrapLayerFSOnSD.AutoSize = true;
             this.cbScrapLayerFSOnSD.Enabled = false;
-            this.cbScrapLayerFSOnSD.Location = new System.Drawing.Point(26, 109);
-            this.cbScrapLayerFSOnSD.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cbScrapLayerFSOnSD.Location = new System.Drawing.Point(17, 71);
             this.cbScrapLayerFSOnSD.Name = "cbScrapLayerFSOnSD";
-            this.cbScrapLayerFSOnSD.Size = new System.Drawing.Size(185, 24);
+            this.cbScrapLayerFSOnSD.Size = new System.Drawing.Size(123, 17);
             this.cbScrapLayerFSOnSD.TabIndex = 3;
-            this.cbScrapLayerFSOnSD.Text = "Installed e-shop titles";
+            this.cbScrapLayerFSOnSD.Text = "Installed eShop titles";
             this.cbScrapLayerFSOnSD.UseVisualStyleBackColor = true;
             // 
             // cbScrapNSPOnSD
             // 
             this.cbScrapNSPOnSD.AutoSize = true;
-            this.cbScrapNSPOnSD.Location = new System.Drawing.Point(26, 74);
-            this.cbScrapNSPOnSD.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cbScrapNSPOnSD.Location = new System.Drawing.Point(17, 48);
             this.cbScrapNSPOnSD.Name = "cbScrapNSPOnSD";
-            this.cbScrapNSPOnSD.Size = new System.Drawing.Size(167, 24);
+            this.cbScrapNSPOnSD.Size = new System.Drawing.Size(112, 17);
             this.cbScrapNSPOnSD.TabIndex = 2;
-            this.cbScrapNSPOnSD.Text = "NSP Files (e-shop)";
+            this.cbScrapNSPOnSD.Text = "NSP Files (eShop)";
             this.cbScrapNSPOnSD.UseVisualStyleBackColor = true;
             // 
             // cbScrapXCIOnSD
             // 
             this.cbScrapXCIOnSD.AutoSize = true;
-            this.cbScrapXCIOnSD.Location = new System.Drawing.Point(26, 38);
-            this.cbScrapXCIOnSD.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cbScrapXCIOnSD.Location = new System.Drawing.Point(17, 25);
             this.cbScrapXCIOnSD.Name = "cbScrapXCIOnSD";
-            this.cbScrapXCIOnSD.Size = new System.Drawing.Size(148, 24);
+            this.cbScrapXCIOnSD.Size = new System.Drawing.Size(99, 17);
             this.cbScrapXCIOnSD.TabIndex = 1;
             this.cbScrapXCIOnSD.Text = "XCI Files (carts)";
             this.cbScrapXCIOnSD.UseVisualStyleBackColor = true;
             // 
             // tabPage2
             // 
-            this.tabPage2.Controls.Add(this.label1);
-            this.tabPage2.Controls.Add(this.groupBox5);
+            this.tabPage2.Controls.Add(this.versionHighlightsGroup);
+            this.tabPage2.Controls.Add(this.labelRequiresRestart);
+            this.tabPage2.Controls.Add(this.sceneHighlightsGroup);
             this.tabPage2.Controls.Add(this.cbShowCompletePaths);
-            this.tabPage2.Location = new System.Drawing.Point(4, 29);
-            this.tabPage2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.tabPage2.Location = new System.Drawing.Point(4, 22);
             this.tabPage2.Name = "tabPage2";
-            this.tabPage2.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.tabPage2.Size = new System.Drawing.Size(918, 641);
+            this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage2.Size = new System.Drawing.Size(609, 412);
             this.tabPage2.TabIndex = 1;
             this.tabPage2.Text = "Visual";
             this.tabPage2.UseVisualStyleBackColor = true;
             // 
-            // label1
+            // versionHighlightsGroup
             // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(15, 568);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(395, 20);
-            this.label1.TabIndex = 2;
-            this.label1.Text = "* Changes made here requires a restart of the program";
+            this.versionHighlightsGroup.Controls.Add(this.labelVersionsWithUpdate);
+            this.versionHighlightsGroup.Controls.Add(this.btnColorVersion);
+            this.versionHighlightsGroup.Controls.Add(this.cbHighlightVersionOnNSP);
+            this.versionHighlightsGroup.Controls.Add(this.cbHighlightVersionOnXCI);
+            this.versionHighlightsGroup.Location = new System.Drawing.Point(308, 17);
+            this.versionHighlightsGroup.Name = "versionHighlightsGroup";
+            this.versionHighlightsGroup.Size = new System.Drawing.Size(290, 100);
+            this.versionHighlightsGroup.TabIndex = 6;
+            this.versionHighlightsGroup.TabStop = false;
+            this.versionHighlightsGroup.Text = "Game Version Highlights";
             // 
-            // groupBox5
+            // labelVersionsWithUpdate
             // 
-            this.groupBox5.Controls.Add(this.btnColorBoth);
-            this.groupBox5.Controls.Add(this.btnColorEshop);
-            this.groupBox5.Controls.Add(this.btnColorXCI);
-            this.groupBox5.Controls.Add(this.cbHighlightBothOnScene);
-            this.groupBox5.Controls.Add(this.cbHighlightNSPOnScene);
-            this.groupBox5.Controls.Add(this.cbHighlightXCIOnScene);
-            this.groupBox5.Location = new System.Drawing.Point(15, 28);
-            this.groupBox5.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.groupBox5.Name = "groupBox5";
-            this.groupBox5.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.groupBox5.Size = new System.Drawing.Size(428, 143);
-            this.groupBox5.TabIndex = 1;
-            this.groupBox5.TabStop = false;
-            this.groupBox5.Text = "Highlights on scene list";
+            this.labelVersionsWithUpdate.AutoSize = true;
+            this.labelVersionsWithUpdate.Location = new System.Drawing.Point(14, 25);
+            this.labelVersionsWithUpdate.Name = "labelVersionsWithUpdate";
+            this.labelVersionsWithUpdate.Size = new System.Drawing.Size(108, 13);
+            this.labelVersionsWithUpdate.TabIndex = 0;
+            this.labelVersionsWithUpdate.Text = "Versions with update:";
+            // 
+            // btnColorVersion
+            // 
+            this.btnColorVersion.BackColor = System.Drawing.Color.LightPink;
+            this.btnColorVersion.Location = new System.Drawing.Point(150, 20);
+            this.btnColorVersion.Name = "btnColorVersion";
+            this.btnColorVersion.Size = new System.Drawing.Size(24, 24);
+            this.btnColorVersion.TabIndex = 8;
+            this.btnColorVersion.UseVisualStyleBackColor = false;
+            this.btnColorVersion.Click += new System.EventHandler(this.btnColorVersion_Click);
+            // 
+            // cbHighlightVersionOnNSP
+            // 
+            this.cbHighlightVersionOnNSP.AutoSize = true;
+            this.cbHighlightVersionOnNSP.Location = new System.Drawing.Point(28, 71);
+            this.cbHighlightVersionOnNSP.Name = "cbHighlightVersionOnNSP";
+            this.cbHighlightVersionOnNSP.Size = new System.Drawing.Size(75, 17);
+            this.cbHighlightVersionOnNSP.TabIndex = 7;
+            this.cbHighlightVersionOnNSP.Text = "In NSP list";
+            this.cbHighlightVersionOnNSP.UseVisualStyleBackColor = true;
+            // 
+            // cbHighlightVersionOnXCI
+            // 
+            this.cbHighlightVersionOnXCI.AutoSize = true;
+            this.cbHighlightVersionOnXCI.Location = new System.Drawing.Point(28, 48);
+            this.cbHighlightVersionOnXCI.Name = "cbHighlightVersionOnXCI";
+            this.cbHighlightVersionOnXCI.Size = new System.Drawing.Size(70, 17);
+            this.cbHighlightVersionOnXCI.TabIndex = 6;
+            this.cbHighlightVersionOnXCI.Text = "In XCI list";
+            this.cbHighlightVersionOnXCI.UseVisualStyleBackColor = true;
+            // 
+            // labelRequiresRestart
+            // 
+            this.labelRequiresRestart.AutoSize = true;
+            this.labelRequiresRestart.Location = new System.Drawing.Point(6, 380);
+            this.labelRequiresRestart.Name = "labelRequiresRestart";
+            this.labelRequiresRestart.Size = new System.Drawing.Size(256, 13);
+            this.labelRequiresRestart.TabIndex = 0;
+            this.labelRequiresRestart.Text = "* Changes made here require a restart of the program";
+            // 
+            // sceneHighlightsGroup
+            // 
+            this.sceneHighlightsGroup.Controls.Add(this.btnColorBoth);
+            this.sceneHighlightsGroup.Controls.Add(this.btnColorEshop);
+            this.sceneHighlightsGroup.Controls.Add(this.btnColorXCI);
+            this.sceneHighlightsGroup.Controls.Add(this.cbHighlightBothOnScene);
+            this.sceneHighlightsGroup.Controls.Add(this.cbHighlightNSPOnScene);
+            this.sceneHighlightsGroup.Controls.Add(this.cbHighlightXCIOnScene);
+            this.sceneHighlightsGroup.Location = new System.Drawing.Point(10, 17);
+            this.sceneHighlightsGroup.Name = "sceneHighlightsGroup";
+            this.sceneHighlightsGroup.Size = new System.Drawing.Size(290, 100);
+            this.sceneHighlightsGroup.TabIndex = 0;
+            this.sceneHighlightsGroup.TabStop = false;
+            this.sceneHighlightsGroup.Text = "Scene List Highlights";
             // 
             // btnColorBoth
             // 
             this.btnColorBoth.BackColor = System.Drawing.Color.Yellow;
-            this.btnColorBoth.Location = new System.Drawing.Point(222, 92);
-            this.btnColorBoth.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.btnColorBoth.Location = new System.Drawing.Point(148, 69);
             this.btnColorBoth.Name = "btnColorBoth";
-            this.btnColorBoth.Size = new System.Drawing.Size(36, 37);
+            this.btnColorBoth.Size = new System.Drawing.Size(24, 24);
             this.btnColorBoth.TabIndex = 5;
             this.btnColorBoth.UseVisualStyleBackColor = false;
             this.btnColorBoth.Click += new System.EventHandler(this.btnColorBoth_Click);
@@ -426,10 +458,9 @@
             // btnColorEshop
             // 
             this.btnColorEshop.BackColor = System.Drawing.Color.Orange;
-            this.btnColorEshop.Location = new System.Drawing.Point(222, 55);
-            this.btnColorEshop.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.btnColorEshop.Location = new System.Drawing.Point(148, 44);
             this.btnColorEshop.Name = "btnColorEshop";
-            this.btnColorEshop.Size = new System.Drawing.Size(36, 37);
+            this.btnColorEshop.Size = new System.Drawing.Size(24, 24);
             this.btnColorEshop.TabIndex = 4;
             this.btnColorEshop.UseVisualStyleBackColor = false;
             this.btnColorEshop.Click += new System.EventHandler(this.btnColorEshop_Click);
@@ -437,10 +468,9 @@
             // btnColorXCI
             // 
             this.btnColorXCI.BackColor = System.Drawing.Color.Green;
-            this.btnColorXCI.Location = new System.Drawing.Point(222, 18);
-            this.btnColorXCI.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.btnColorXCI.Location = new System.Drawing.Point(148, 20);
             this.btnColorXCI.Name = "btnColorXCI";
-            this.btnColorXCI.Size = new System.Drawing.Size(36, 37);
+            this.btnColorXCI.Size = new System.Drawing.Size(24, 24);
             this.btnColorXCI.TabIndex = 3;
             this.btnColorXCI.UseVisualStyleBackColor = false;
             this.btnColorXCI.Click += new System.EventHandler(this.btnColorXCI_Click);
@@ -448,55 +478,50 @@
             // cbHighlightBothOnScene
             // 
             this.cbHighlightBothOnScene.AutoSize = true;
-            this.cbHighlightBothOnScene.Location = new System.Drawing.Point(10, 103);
-            this.cbHighlightBothOnScene.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cbHighlightBothOnScene.Location = new System.Drawing.Point(17, 71);
             this.cbHighlightBothOnScene.Name = "cbHighlightBothOnScene";
-            this.cbHighlightBothOnScene.Size = new System.Drawing.Size(176, 24);
+            this.cbHighlightBothOnScene.Size = new System.Drawing.Size(114, 17);
             this.cbHighlightBothOnScene.TabIndex = 2;
-            this.cbHighlightBothOnScene.Text = "Games on both lists";
+            this.cbHighlightBothOnScene.Text = "Games in both lists";
             this.cbHighlightBothOnScene.UseVisualStyleBackColor = true;
             // 
             // cbHighlightNSPOnScene
             // 
             this.cbHighlightNSPOnScene.AutoSize = true;
-            this.cbHighlightNSPOnScene.Location = new System.Drawing.Point(10, 68);
-            this.cbHighlightNSPOnScene.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cbHighlightNSPOnScene.Location = new System.Drawing.Point(17, 48);
             this.cbHighlightNSPOnScene.Name = "cbHighlightNSPOnScene";
-            this.cbHighlightNSPOnScene.Size = new System.Drawing.Size(180, 24);
+            this.cbHighlightNSPOnScene.Size = new System.Drawing.Size(110, 17);
             this.cbHighlightNSPOnScene.TabIndex = 1;
-            this.cbHighlightNSPOnScene.Text = "Games on eshop list";
+            this.cbHighlightNSPOnScene.Text = "Games in NSP list";
             this.cbHighlightNSPOnScene.UseVisualStyleBackColor = true;
             // 
             // cbHighlightXCIOnScene
             // 
             this.cbHighlightXCIOnScene.AutoSize = true;
-            this.cbHighlightXCIOnScene.Location = new System.Drawing.Point(10, 31);
-            this.cbHighlightXCIOnScene.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cbHighlightXCIOnScene.Location = new System.Drawing.Point(17, 25);
             this.cbHighlightXCIOnScene.Name = "cbHighlightXCIOnScene";
-            this.cbHighlightXCIOnScene.Size = new System.Drawing.Size(163, 24);
+            this.cbHighlightXCIOnScene.Size = new System.Drawing.Size(105, 17);
             this.cbHighlightXCIOnScene.TabIndex = 0;
-            this.cbHighlightXCIOnScene.Text = "Games on XCI list";
+            this.cbHighlightXCIOnScene.Text = "Games in XCI list";
             this.cbHighlightXCIOnScene.UseVisualStyleBackColor = true;
             // 
             // cbShowCompletePaths
             // 
             this.cbShowCompletePaths.AutoSize = true;
-            this.cbShowCompletePaths.Location = new System.Drawing.Point(15, 208);
-            this.cbShowCompletePaths.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cbShowCompletePaths.Location = new System.Drawing.Point(10, 135);
             this.cbShowCompletePaths.Name = "cbShowCompletePaths";
-            this.cbShowCompletePaths.Size = new System.Drawing.Size(310, 24);
+            this.cbShowCompletePaths.Size = new System.Drawing.Size(205, 17);
             this.cbShowCompletePaths.TabIndex = 0;
-            this.cbShowCompletePaths.Text = "Show complete path of files on the lists";
+            this.cbShowCompletePaths.Text = "Show complete path of files in the lists";
             this.cbShowCompletePaths.UseVisualStyleBackColor = true;
             // 
             // tabPage3
             // 
             this.tabPage3.Controls.Add(this.tabControl2);
-            this.tabPage3.Location = new System.Drawing.Point(4, 29);
-            this.tabPage3.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.tabPage3.Location = new System.Drawing.Point(4, 22);
             this.tabPage3.Name = "tabPage3";
-            this.tabPage3.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.tabPage3.Size = new System.Drawing.Size(918, 641);
+            this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage3.Size = new System.Drawing.Size(609, 412);
             this.tabPage3.TabIndex = 2;
             this.tabPage3.Text = "Auto renaming";
             this.tabPage3.UseVisualStyleBackColor = true;
@@ -506,21 +531,19 @@
             this.tabControl2.Controls.Add(this.tabPage4);
             this.tabControl2.Controls.Add(this.tabPage5);
             this.tabControl2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tabControl2.Location = new System.Drawing.Point(4, 5);
-            this.tabControl2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.tabControl2.Location = new System.Drawing.Point(3, 3);
             this.tabControl2.Name = "tabControl2";
             this.tabControl2.SelectedIndex = 0;
-            this.tabControl2.Size = new System.Drawing.Size(910, 631);
+            this.tabControl2.Size = new System.Drawing.Size(603, 406);
             this.tabControl2.TabIndex = 2;
             // 
             // tabPage4
             // 
             this.tabPage4.Controls.Add(this.groupBox1);
-            this.tabPage4.Location = new System.Drawing.Point(4, 29);
-            this.tabPage4.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.tabPage4.Location = new System.Drawing.Point(4, 22);
             this.tabPage4.Name = "tabPage4";
-            this.tabPage4.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.tabPage4.Size = new System.Drawing.Size(902, 598);
+            this.tabPage4.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage4.Size = new System.Drawing.Size(595, 380);
             this.tabPage4.TabIndex = 0;
             this.tabPage4.Text = "XCI files";
             this.tabPage4.UseVisualStyleBackColor = true;
@@ -535,11 +558,9 @@
             this.groupBox1.Controls.Add(this.gbCustom);
             this.groupBox1.Controls.Add(this.rbRenamingTitleIDGameNameXCI);
             this.groupBox1.Controls.Add(this.rbRenamingGameNameXCI);
-            this.groupBox1.Location = new System.Drawing.Point(4, 3);
-            this.groupBox1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox1.Location = new System.Drawing.Point(3, 2);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.groupBox1.Size = new System.Drawing.Size(882, 560);
+            this.groupBox1.Size = new System.Drawing.Size(588, 375);
             this.groupBox1.TabIndex = 2;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Choose pattern";
@@ -547,10 +568,9 @@
             // rbRenamingGameNameRegionFirmwareXCI
             // 
             this.rbRenamingGameNameRegionFirmwareXCI.AutoSize = true;
-            this.rbRenamingGameNameRegionFirmwareXCI.Location = new System.Drawing.Point(28, 115);
-            this.rbRenamingGameNameRegionFirmwareXCI.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.rbRenamingGameNameRegionFirmwareXCI.Location = new System.Drawing.Point(19, 75);
             this.rbRenamingGameNameRegionFirmwareXCI.Name = "rbRenamingGameNameRegionFirmwareXCI";
-            this.rbRenamingGameNameRegionFirmwareXCI.Size = new System.Drawing.Size(266, 24);
+            this.rbRenamingGameNameRegionFirmwareXCI.Size = new System.Drawing.Size(176, 17);
             this.rbRenamingGameNameRegionFirmwareXCI.TabIndex = 6;
             this.rbRenamingGameNameRegionFirmwareXCI.Text = "Game name (Region) (Firmware)";
             this.rbRenamingGameNameRegionFirmwareXCI.UseVisualStyleBackColor = true;
@@ -559,10 +579,9 @@
             // rbRenamingGameNameRegionXCI
             // 
             this.rbRenamingGameNameRegionXCI.AutoSize = true;
-            this.rbRenamingGameNameRegionXCI.Location = new System.Drawing.Point(28, 80);
-            this.rbRenamingGameNameRegionXCI.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.rbRenamingGameNameRegionXCI.Location = new System.Drawing.Point(19, 52);
             this.rbRenamingGameNameRegionXCI.Name = "rbRenamingGameNameRegionXCI";
-            this.rbRenamingGameNameRegionXCI.Size = new System.Drawing.Size(187, 24);
+            this.rbRenamingGameNameRegionXCI.Size = new System.Drawing.Size(125, 17);
             this.rbRenamingGameNameRegionXCI.TabIndex = 5;
             this.rbRenamingGameNameRegionXCI.Text = "Game name (Region)";
             this.rbRenamingGameNameRegionXCI.UseVisualStyleBackColor = true;
@@ -571,10 +590,9 @@
             // lblExample
             // 
             this.lblExample.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblExample.Location = new System.Drawing.Point(16, 485);
-            this.lblExample.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblExample.Location = new System.Drawing.Point(11, 315);
             this.lblExample.Name = "lblExample";
-            this.lblExample.Size = new System.Drawing.Size(849, 71);
+            this.lblExample.Size = new System.Drawing.Size(566, 46);
             this.lblExample.TabIndex = 1;
             this.lblExample.Text = "Super Mario Odyssey.xci";
             this.lblExample.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -582,10 +600,9 @@
             // rbRenamingCustomXCI
             // 
             this.rbRenamingCustomXCI.AutoSize = true;
-            this.rbRenamingCustomXCI.Location = new System.Drawing.Point(28, 223);
-            this.rbRenamingCustomXCI.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.rbRenamingCustomXCI.Location = new System.Drawing.Point(19, 145);
             this.rbRenamingCustomXCI.Name = "rbRenamingCustomXCI";
-            this.rbRenamingCustomXCI.Size = new System.Drawing.Size(89, 24);
+            this.rbRenamingCustomXCI.Size = new System.Drawing.Size(60, 17);
             this.rbRenamingCustomXCI.TabIndex = 4;
             this.rbRenamingCustomXCI.Text = "Custom";
             this.rbRenamingCustomXCI.UseVisualStyleBackColor = true;
@@ -594,10 +611,9 @@
             // rbRenamingTitleIDGameNameReleaseGroupXCI
             // 
             this.rbRenamingTitleIDGameNameReleaseGroupXCI.AutoSize = true;
-            this.rbRenamingTitleIDGameNameReleaseGroupXCI.Location = new System.Drawing.Point(28, 188);
-            this.rbRenamingTitleIDGameNameReleaseGroupXCI.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.rbRenamingTitleIDGameNameReleaseGroupXCI.Location = new System.Drawing.Point(19, 122);
             this.rbRenamingTitleIDGameNameReleaseGroupXCI.Name = "rbRenamingTitleIDGameNameReleaseGroupXCI";
-            this.rbRenamingTitleIDGameNameReleaseGroupXCI.Size = new System.Drawing.Size(302, 24);
+            this.rbRenamingTitleIDGameNameReleaseGroupXCI.Size = new System.Drawing.Size(203, 17);
             this.rbRenamingTitleIDGameNameReleaseGroupXCI.TabIndex = 3;
             this.rbRenamingTitleIDGameNameReleaseGroupXCI.Text = "Title ID - Game name - Release group";
             this.rbRenamingTitleIDGameNameReleaseGroupXCI.UseVisualStyleBackColor = true;
@@ -608,11 +624,9 @@
             this.gbCustom.Controls.Add(this.btnAddXCI);
             this.gbCustom.Controls.Add(this.textBoxCustomPaternXCI);
             this.gbCustom.Controls.Add(this.cbxTagsXCI);
-            this.gbCustom.Location = new System.Drawing.Point(28, 306);
-            this.gbCustom.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.gbCustom.Location = new System.Drawing.Point(19, 199);
             this.gbCustom.Name = "gbCustom";
-            this.gbCustom.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.gbCustom.Size = new System.Drawing.Size(844, 77);
+            this.gbCustom.Size = new System.Drawing.Size(563, 50);
             this.gbCustom.TabIndex = 2;
             this.gbCustom.TabStop = false;
             this.gbCustom.Text = "Custom pattern";
@@ -621,10 +635,9 @@
             // btnAddXCI
             // 
             this.btnAddXCI.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnAddXCI.Location = new System.Drawing.Point(128, 28);
-            this.btnAddXCI.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.btnAddXCI.Location = new System.Drawing.Point(85, 18);
             this.btnAddXCI.Name = "btnAddXCI";
-            this.btnAddXCI.Size = new System.Drawing.Size(38, 35);
+            this.btnAddXCI.Size = new System.Drawing.Size(25, 23);
             this.btnAddXCI.TabIndex = 2;
             this.btnAddXCI.Text = "+";
             this.btnAddXCI.UseVisualStyleBackColor = true;
@@ -632,10 +645,9 @@
             // 
             // textBoxCustomPaternXCI
             // 
-            this.textBoxCustomPaternXCI.Location = new System.Drawing.Point(172, 29);
-            this.textBoxCustomPaternXCI.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.textBoxCustomPaternXCI.Location = new System.Drawing.Point(115, 19);
             this.textBoxCustomPaternXCI.Name = "textBoxCustomPaternXCI";
-            this.textBoxCustomPaternXCI.Size = new System.Drawing.Size(661, 26);
+            this.textBoxCustomPaternXCI.Size = new System.Drawing.Size(442, 20);
             this.textBoxCustomPaternXCI.TabIndex = 1;
             this.textBoxCustomPaternXCI.TextChanged += new System.EventHandler(this.textBoxCustomPatern_TextChanged);
             // 
@@ -649,19 +661,17 @@
             "Developer",
             "Trimmed",
             "Revision"});
-            this.cbxTagsXCI.Location = new System.Drawing.Point(9, 29);
-            this.cbxTagsXCI.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cbxTagsXCI.Location = new System.Drawing.Point(6, 19);
             this.cbxTagsXCI.Name = "cbxTagsXCI";
-            this.cbxTagsXCI.Size = new System.Drawing.Size(109, 28);
+            this.cbxTagsXCI.Size = new System.Drawing.Size(74, 21);
             this.cbxTagsXCI.TabIndex = 0;
             // 
             // rbRenamingTitleIDGameNameXCI
             // 
             this.rbRenamingTitleIDGameNameXCI.AutoSize = true;
-            this.rbRenamingTitleIDGameNameXCI.Location = new System.Drawing.Point(28, 152);
-            this.rbRenamingTitleIDGameNameXCI.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.rbRenamingTitleIDGameNameXCI.Location = new System.Drawing.Point(19, 99);
             this.rbRenamingTitleIDGameNameXCI.Name = "rbRenamingTitleIDGameNameXCI";
-            this.rbRenamingTitleIDGameNameXCI.Size = new System.Drawing.Size(185, 24);
+            this.rbRenamingTitleIDGameNameXCI.Size = new System.Drawing.Size(125, 17);
             this.rbRenamingTitleIDGameNameXCI.TabIndex = 1;
             this.rbRenamingTitleIDGameNameXCI.Text = "Title ID - Game name";
             this.rbRenamingTitleIDGameNameXCI.UseVisualStyleBackColor = true;
@@ -671,10 +681,9 @@
             // 
             this.rbRenamingGameNameXCI.AutoSize = true;
             this.rbRenamingGameNameXCI.Checked = true;
-            this.rbRenamingGameNameXCI.Location = new System.Drawing.Point(28, 45);
-            this.rbRenamingGameNameXCI.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.rbRenamingGameNameXCI.Location = new System.Drawing.Point(19, 29);
             this.rbRenamingGameNameXCI.Name = "rbRenamingGameNameXCI";
-            this.rbRenamingGameNameXCI.Size = new System.Drawing.Size(122, 24);
+            this.rbRenamingGameNameXCI.Size = new System.Drawing.Size(82, 17);
             this.rbRenamingGameNameXCI.TabIndex = 0;
             this.rbRenamingGameNameXCI.TabStop = true;
             this.rbRenamingGameNameXCI.Text = "Game name";
@@ -684,11 +693,10 @@
             // tabPage5
             // 
             this.tabPage5.Controls.Add(this.groupBox4);
-            this.tabPage5.Location = new System.Drawing.Point(4, 29);
-            this.tabPage5.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.tabPage5.Location = new System.Drawing.Point(4, 22);
             this.tabPage5.Name = "tabPage5";
-            this.tabPage5.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.tabPage5.Size = new System.Drawing.Size(902, 580);
+            this.tabPage5.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage5.Size = new System.Drawing.Size(595, 380);
             this.tabPage5.TabIndex = 1;
             this.tabPage5.Text = "NSP files";
             this.tabPage5.UseVisualStyleBackColor = true;
@@ -705,11 +713,9 @@
             this.groupBox4.Controls.Add(this.gbCustomNSP);
             this.groupBox4.Controls.Add(this.rbRenamingTitleIDGameNameNSP);
             this.groupBox4.Controls.Add(this.rbRenamingGameNameNSP);
-            this.groupBox4.Location = new System.Drawing.Point(4, 3);
-            this.groupBox4.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox4.Location = new System.Drawing.Point(3, 2);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.groupBox4.Size = new System.Drawing.Size(882, 560);
+            this.groupBox4.Size = new System.Drawing.Size(588, 364);
             this.groupBox4.TabIndex = 3;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Choose pattern";
@@ -718,46 +724,41 @@
             // 
             this.groupBox6.Controls.Add(this.textLimitFileNameSizeNSP);
             this.groupBox6.Controls.Add(this.label2);
-            this.groupBox6.Location = new System.Drawing.Point(28, 294);
-            this.groupBox6.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox6.Location = new System.Drawing.Point(19, 191);
             this.groupBox6.Name = "groupBox6";
-            this.groupBox6.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.groupBox6.Size = new System.Drawing.Size(198, 77);
+            this.groupBox6.Size = new System.Drawing.Size(132, 50);
             this.groupBox6.TabIndex = 8;
             this.groupBox6.TabStop = false;
             this.groupBox6.Text = "Limit filename size";
             // 
             // textLimitFileNameSizeNSP
             // 
-            this.textLimitFileNameSizeNSP.Location = new System.Drawing.Point(9, 34);
-            this.textLimitFileNameSizeNSP.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.textLimitFileNameSizeNSP.Location = new System.Drawing.Point(6, 22);
             this.textLimitFileNameSizeNSP.Maximum = new decimal(new int[] {
             255,
             0,
             0,
             0});
             this.textLimitFileNameSizeNSP.Name = "textLimitFileNameSizeNSP";
-            this.textLimitFileNameSizeNSP.Size = new System.Drawing.Size(82, 26);
+            this.textLimitFileNameSizeNSP.Size = new System.Drawing.Size(55, 20);
             this.textLimitFileNameSizeNSP.TabIndex = 2;
             this.textLimitFileNameSizeNSP.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.textLimitFileNameSizeNSP_KeyPress);
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(100, 37);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(67, 24);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(84, 20);
+            this.label2.Size = new System.Drawing.Size(57, 13);
             this.label2.TabIndex = 1;
             this.label2.Text = "0 = no limit";
             // 
             // rbRenamingCDNSP
             // 
             this.rbRenamingCDNSP.AutoSize = true;
-            this.rbRenamingCDNSP.Location = new System.Drawing.Point(28, 223);
-            this.rbRenamingCDNSP.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.rbRenamingCDNSP.Location = new System.Drawing.Point(19, 145);
             this.rbRenamingCDNSP.Name = "rbRenamingCDNSP";
-            this.rbRenamingCDNSP.Size = new System.Drawing.Size(178, 24);
+            this.rbRenamingCDNSP.Size = new System.Drawing.Size(119, 17);
             this.rbRenamingCDNSP.TabIndex = 7;
             this.rbRenamingCDNSP.Text = "CDNSP GUI Format";
             this.rbRenamingCDNSP.UseVisualStyleBackColor = true;
@@ -766,10 +767,9 @@
             // rbRenamingGameNameRegionFirmwareNSP
             // 
             this.rbRenamingGameNameRegionFirmwareNSP.AutoSize = true;
-            this.rbRenamingGameNameRegionFirmwareNSP.Location = new System.Drawing.Point(28, 115);
-            this.rbRenamingGameNameRegionFirmwareNSP.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.rbRenamingGameNameRegionFirmwareNSP.Location = new System.Drawing.Point(19, 75);
             this.rbRenamingGameNameRegionFirmwareNSP.Name = "rbRenamingGameNameRegionFirmwareNSP";
-            this.rbRenamingGameNameRegionFirmwareNSP.Size = new System.Drawing.Size(266, 24);
+            this.rbRenamingGameNameRegionFirmwareNSP.Size = new System.Drawing.Size(176, 17);
             this.rbRenamingGameNameRegionFirmwareNSP.TabIndex = 6;
             this.rbRenamingGameNameRegionFirmwareNSP.Text = "Game name (Region) (Firmware)";
             this.rbRenamingGameNameRegionFirmwareNSP.UseVisualStyleBackColor = true;
@@ -778,10 +778,9 @@
             // rbRenamingGameNameRegionNSP
             // 
             this.rbRenamingGameNameRegionNSP.AutoSize = true;
-            this.rbRenamingGameNameRegionNSP.Location = new System.Drawing.Point(28, 80);
-            this.rbRenamingGameNameRegionNSP.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.rbRenamingGameNameRegionNSP.Location = new System.Drawing.Point(19, 52);
             this.rbRenamingGameNameRegionNSP.Name = "rbRenamingGameNameRegionNSP";
-            this.rbRenamingGameNameRegionNSP.Size = new System.Drawing.Size(187, 24);
+            this.rbRenamingGameNameRegionNSP.Size = new System.Drawing.Size(125, 17);
             this.rbRenamingGameNameRegionNSP.TabIndex = 5;
             this.rbRenamingGameNameRegionNSP.Text = "Game name (Region)";
             this.rbRenamingGameNameRegionNSP.UseVisualStyleBackColor = true;
@@ -790,10 +789,9 @@
             // lblExampleNSP
             // 
             this.lblExampleNSP.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblExampleNSP.Location = new System.Drawing.Point(16, 485);
-            this.lblExampleNSP.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblExampleNSP.Location = new System.Drawing.Point(11, 315);
             this.lblExampleNSP.Name = "lblExampleNSP";
-            this.lblExampleNSP.Size = new System.Drawing.Size(849, 71);
+            this.lblExampleNSP.Size = new System.Drawing.Size(566, 46);
             this.lblExampleNSP.TabIndex = 1;
             this.lblExampleNSP.Text = "Super Mario Odyssey.xci";
             this.lblExampleNSP.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -801,10 +799,9 @@
             // rbRenamingCustomNSP
             // 
             this.rbRenamingCustomNSP.AutoSize = true;
-            this.rbRenamingCustomNSP.Location = new System.Drawing.Point(28, 258);
-            this.rbRenamingCustomNSP.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.rbRenamingCustomNSP.Location = new System.Drawing.Point(19, 168);
             this.rbRenamingCustomNSP.Name = "rbRenamingCustomNSP";
-            this.rbRenamingCustomNSP.Size = new System.Drawing.Size(89, 24);
+            this.rbRenamingCustomNSP.Size = new System.Drawing.Size(60, 17);
             this.rbRenamingCustomNSP.TabIndex = 4;
             this.rbRenamingCustomNSP.Text = "Custom";
             this.rbRenamingCustomNSP.UseVisualStyleBackColor = true;
@@ -813,10 +810,9 @@
             // rbRenamingTitleIDGameNameReleaseGroupNSP
             // 
             this.rbRenamingTitleIDGameNameReleaseGroupNSP.AutoSize = true;
-            this.rbRenamingTitleIDGameNameReleaseGroupNSP.Location = new System.Drawing.Point(28, 188);
-            this.rbRenamingTitleIDGameNameReleaseGroupNSP.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.rbRenamingTitleIDGameNameReleaseGroupNSP.Location = new System.Drawing.Point(19, 122);
             this.rbRenamingTitleIDGameNameReleaseGroupNSP.Name = "rbRenamingTitleIDGameNameReleaseGroupNSP";
-            this.rbRenamingTitleIDGameNameReleaseGroupNSP.Size = new System.Drawing.Size(302, 24);
+            this.rbRenamingTitleIDGameNameReleaseGroupNSP.Size = new System.Drawing.Size(203, 17);
             this.rbRenamingTitleIDGameNameReleaseGroupNSP.TabIndex = 3;
             this.rbRenamingTitleIDGameNameReleaseGroupNSP.Text = "Title ID - Game name - Release group";
             this.rbRenamingTitleIDGameNameReleaseGroupNSP.UseVisualStyleBackColor = true;
@@ -827,11 +823,9 @@
             this.gbCustomNSP.Controls.Add(this.btnAddNSP);
             this.gbCustomNSP.Controls.Add(this.textBoxCustomPaternNSP);
             this.gbCustomNSP.Controls.Add(this.cbxTagsNSP);
-            this.gbCustomNSP.Location = new System.Drawing.Point(28, 380);
-            this.gbCustomNSP.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.gbCustomNSP.Location = new System.Drawing.Point(19, 247);
             this.gbCustomNSP.Name = "gbCustomNSP";
-            this.gbCustomNSP.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.gbCustomNSP.Size = new System.Drawing.Size(844, 77);
+            this.gbCustomNSP.Size = new System.Drawing.Size(563, 50);
             this.gbCustomNSP.TabIndex = 2;
             this.gbCustomNSP.TabStop = false;
             this.gbCustomNSP.Text = "Custom pattern";
@@ -840,10 +834,9 @@
             // btnAddNSP
             // 
             this.btnAddNSP.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnAddNSP.Location = new System.Drawing.Point(128, 28);
-            this.btnAddNSP.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.btnAddNSP.Location = new System.Drawing.Point(85, 18);
             this.btnAddNSP.Name = "btnAddNSP";
-            this.btnAddNSP.Size = new System.Drawing.Size(38, 35);
+            this.btnAddNSP.Size = new System.Drawing.Size(25, 23);
             this.btnAddNSP.TabIndex = 2;
             this.btnAddNSP.Text = "+";
             this.btnAddNSP.UseVisualStyleBackColor = true;
@@ -851,10 +844,9 @@
             // 
             // textBoxCustomPaternNSP
             // 
-            this.textBoxCustomPaternNSP.Location = new System.Drawing.Point(172, 29);
-            this.textBoxCustomPaternNSP.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.textBoxCustomPaternNSP.Location = new System.Drawing.Point(115, 19);
             this.textBoxCustomPaternNSP.Name = "textBoxCustomPaternNSP";
-            this.textBoxCustomPaternNSP.Size = new System.Drawing.Size(661, 26);
+            this.textBoxCustomPaternNSP.Size = new System.Drawing.Size(442, 20);
             this.textBoxCustomPaternNSP.TabIndex = 1;
             this.textBoxCustomPaternNSP.TextChanged += new System.EventHandler(this.textBoxCustomPaternNSP_TextChanged);
             // 
@@ -868,19 +860,17 @@
             "Developer",
             "Trimmed",
             "Revision"});
-            this.cbxTagsNSP.Location = new System.Drawing.Point(9, 29);
-            this.cbxTagsNSP.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cbxTagsNSP.Location = new System.Drawing.Point(6, 19);
             this.cbxTagsNSP.Name = "cbxTagsNSP";
-            this.cbxTagsNSP.Size = new System.Drawing.Size(109, 28);
+            this.cbxTagsNSP.Size = new System.Drawing.Size(74, 21);
             this.cbxTagsNSP.TabIndex = 0;
             // 
             // rbRenamingTitleIDGameNameNSP
             // 
             this.rbRenamingTitleIDGameNameNSP.AutoSize = true;
-            this.rbRenamingTitleIDGameNameNSP.Location = new System.Drawing.Point(28, 152);
-            this.rbRenamingTitleIDGameNameNSP.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.rbRenamingTitleIDGameNameNSP.Location = new System.Drawing.Point(19, 99);
             this.rbRenamingTitleIDGameNameNSP.Name = "rbRenamingTitleIDGameNameNSP";
-            this.rbRenamingTitleIDGameNameNSP.Size = new System.Drawing.Size(185, 24);
+            this.rbRenamingTitleIDGameNameNSP.Size = new System.Drawing.Size(125, 17);
             this.rbRenamingTitleIDGameNameNSP.TabIndex = 1;
             this.rbRenamingTitleIDGameNameNSP.Text = "Title ID - Game name";
             this.rbRenamingTitleIDGameNameNSP.UseVisualStyleBackColor = true;
@@ -890,10 +880,9 @@
             // 
             this.rbRenamingGameNameNSP.AutoSize = true;
             this.rbRenamingGameNameNSP.Checked = true;
-            this.rbRenamingGameNameNSP.Location = new System.Drawing.Point(28, 45);
-            this.rbRenamingGameNameNSP.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.rbRenamingGameNameNSP.Location = new System.Drawing.Point(19, 29);
             this.rbRenamingGameNameNSP.Name = "rbRenamingGameNameNSP";
-            this.rbRenamingGameNameNSP.Size = new System.Drawing.Size(122, 24);
+            this.rbRenamingGameNameNSP.Size = new System.Drawing.Size(82, 17);
             this.rbRenamingGameNameNSP.TabIndex = 0;
             this.rbRenamingGameNameNSP.TabStop = true;
             this.rbRenamingGameNameNSP.Text = "Game name";
@@ -902,13 +891,12 @@
             // 
             // FormConfigs
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(926, 729);
+            this.ClientSize = new System.Drawing.Size(617, 474);
             this.Controls.Add(this.panel2);
             this.Controls.Add(this.panel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
-            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "FormConfigs";
@@ -925,8 +913,10 @@
             this.groupBox2.PerformLayout();
             this.tabPage2.ResumeLayout(false);
             this.tabPage2.PerformLayout();
-            this.groupBox5.ResumeLayout(false);
-            this.groupBox5.PerformLayout();
+            this.versionHighlightsGroup.ResumeLayout(false);
+            this.versionHighlightsGroup.PerformLayout();
+            this.sceneHighlightsGroup.ResumeLayout(false);
+            this.sceneHighlightsGroup.PerformLayout();
             this.tabPage3.ResumeLayout(false);
             this.tabControl2.ResumeLayout(false);
             this.tabPage4.ResumeLayout(false);
@@ -1001,16 +991,21 @@
         private System.Windows.Forms.NumericUpDown textLimitFileNameSizeNSP;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.CheckBox cbShowCompletePaths;
-        private System.Windows.Forms.GroupBox groupBox5;
+        private System.Windows.Forms.GroupBox sceneHighlightsGroup;
         private System.Windows.Forms.Button btnColorBoth;
         private System.Windows.Forms.Button btnColorEshop;
         private System.Windows.Forms.Button btnColorXCI;
         private System.Windows.Forms.CheckBox cbHighlightBothOnScene;
         private System.Windows.Forms.CheckBox cbHighlightNSPOnScene;
         private System.Windows.Forms.CheckBox cbHighlightXCIOnScene;
-        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label labelRequiresRestart;
         private System.Windows.Forms.CheckBox cbUserCanDeleteFiles;
         private System.Windows.Forms.CheckBox cbSendDeletedFileToRecycleBin;
         private System.Windows.Forms.Label labelLastVersionListUpdate;
+        private System.Windows.Forms.GroupBox versionHighlightsGroup;
+        private System.Windows.Forms.Button btnColorVersion;
+        private System.Windows.Forms.CheckBox cbHighlightVersionOnNSP;
+        private System.Windows.Forms.CheckBox cbHighlightVersionOnXCI;
+        private System.Windows.Forms.Label labelVersionsWithUpdate;
     }
 }

--- a/Switch Backup Manager/FormConfigs.cs
+++ b/Switch Backup Manager/FormConfigs.cs
@@ -36,9 +36,9 @@ namespace Switch_Backup_Manager
             gameExample.Version = "0";
 
             gameExampleNSP = new FileData("C:\\Switch\\1-2-Switch [01000320000cc000][v0].nsp", "1-2-Switch [01000320000cc000][v0]", "1-2-Switch [01000320000cc000][v0].nsp",
-                "1,38 GB", 1481339176, "1,38 GB", 1481339176, "01000320000CC000", "01000320000CC000", "1-2-Switch", "Nintendo", "1.0.0", "No Prod. ID", "0.12.12.0", "e-shop",
+                "1,38 GB", 1481339176, "1,38 GB", 1481339176, "01000320000CC000", "01000320000CC000", "1-2-Switch", "Nintendo", "1.0.0", "No Prod. ID", "0.12.12.0", "eShop",
                 "0 (1.0.0-2.3.0)", new Dictionary<string, string> { { "American English", "cache\\icon_01000320000CC000_AmericanEnglish.bmp" }, { "Japanese", "cache\\icon_01000320000CC000_Japanese.bmp" } },
-                new List<string> { "American English", "Japanese" }, "en, ja", true, "", "", "0", "e-shop", "", false, "Download", 0, "Application", "0", "0", true, "", "Nintendo", "Mar 03, 2017",
+                new List<string> { "American English", "Japanese" }, "en, ja", true, "", "", "0", "eShop", "", false, "Download", 0, "Application", "0", "0", true, "", "Nintendo", "Mar 03, 2017",
                 "2 players simultaneous", new List<string> { "Party", "Multiplayer", "Action" }, 0, "");
 
             cbxTagsXCI.Items.Clear();
@@ -88,16 +88,22 @@ namespace Switch_Backup_Manager
             Util.HighlightXCIOnScene = cbHighlightXCIOnScene.Checked;
             Util.HighlightNSPOnScene = cbHighlightNSPOnScene.Checked;
             Util.HighlightBothOnScene = cbHighlightBothOnScene.Checked;
+            Util.HighlightVersionOnXCI = cbHighlightVersionOnXCI.Checked;
+            Util.HighlightVersionOnNSP = cbHighlightVersionOnNSP.Checked;
             Util.HighlightXCIOnScene_color = btnColorXCI.BackColor;
             Util.HighlightNSPOnScene_color = btnColorEshop.BackColor;
             Util.HighlightBothOnScene_color = btnColorBoth.BackColor;
+            Util.HighlightVersion_color = btnColorVersion.BackColor;
 
             Util.ini.IniWriteValue("Visual", "highlightXCIOnScene", Util.HighlightXCIOnScene ? "true" : "false");
             Util.ini.IniWriteValue("Visual", "highlightNSPOnScene", Util.HighlightNSPOnScene ? "true" : "false");
             Util.ini.IniWriteValue("Visual", "highlightBOTHOnScene", Util.HighlightBothOnScene ? "true" : "false");
+            Util.ini.IniWriteValue("Visual", "highlightVersionOnXCI", Util.HighlightVersionOnXCI ? "true" : "false");
+            Util.ini.IniWriteValue("Visual", "highlightVersionOnNSP", Util.HighlightVersionOnNSP ? "true" : "false");
             Util.ini.IniWriteValue("Visual", "highlightXCIOnScene_color", System.Drawing.ColorTranslator.ToHtml(Util.HighlightXCIOnScene_color));
             Util.ini.IniWriteValue("Visual", "highlightNSPOnScene_color", System.Drawing.ColorTranslator.ToHtml(Util.HighlightNSPOnScene_color));
             Util.ini.IniWriteValue("Visual", "highlightBOTHOnScene_color", System.Drawing.ColorTranslator.ToHtml(Util.HighlightBothOnScene_color));
+            Util.ini.IniWriteValue("Visual", "highlightVersion_color", System.Drawing.ColorTranslator.ToHtml(Util.HighlightVersion_color));
 
             Util.AutoUpdateNSDBOnStartup = this.cbAutoUpdateScene.Checked;
             Util.ini.IniWriteValue("Config", "autoUpdateNSWDB", cbAutoUpdateScene.Checked ? "true" : "false");
@@ -138,9 +144,9 @@ namespace Switch_Backup_Manager
                 case "{gamename} ({region}) ({firmware})":
                     rbRenamingGameNameRegionFirmwareXCI.Checked = true;
                     break;
-                //                case "{CDNSP}":
-                //                    rbRenamingCDNSP.Checked = true;
-                //                    break;
+                // case "{CDNSP}":
+                //     rbRenamingCDNSP.Checked = true;
+                //     break;
                 default:
                     textBoxCustomPaternXCI.Text = autoRenamingPattern;
                     rbRenamingCustomXCI.Checked = true;
@@ -190,9 +196,12 @@ namespace Switch_Backup_Manager
             cbHighlightXCIOnScene.Checked = Util.HighlightXCIOnScene;
             cbHighlightNSPOnScene.Checked = Util.HighlightNSPOnScene;
             cbHighlightBothOnScene.Checked = Util.HighlightBothOnScene;
+            cbHighlightVersionOnXCI.Checked = Util.HighlightVersionOnXCI;
+            cbHighlightVersionOnNSP.Checked = Util.HighlightVersionOnNSP;
             this.btnColorXCI.BackColor = Util.HighlightXCIOnScene_color;
             this.btnColorEshop.BackColor = Util.HighlightNSPOnScene_color;
             this.btnColorBoth.BackColor = Util.HighlightBothOnScene_color;
+            this.btnColorVersion.BackColor = Util.HighlightVersion_color;
 
             for (int i = 1; i <= 5; i++)
             {
@@ -437,6 +446,21 @@ namespace Switch_Backup_Manager
             // Update the text box color if the user clicks OK 
             if (MyDialog.ShowDialog() == DialogResult.OK)
                 btnColorBoth.BackColor = MyDialog.Color;
+        }
+
+        private void btnColorVersion_Click(object sender, EventArgs e)
+        {
+            ColorDialog MyDialog = new ColorDialog();
+            // Keeps the user from selecting a custom color.
+            MyDialog.AllowFullOpen = false;
+            // Allows the user to get help. (The default is false.)
+            MyDialog.ShowHelp = true;
+            // Sets the initial color select to the current text color.
+            MyDialog.Color = btnColorVersion.BackColor;
+
+            // Update the text box color if the user clicks OK 
+            if (MyDialog.ShowDialog() == DialogResult.OK)
+                btnColorVersion.BackColor = MyDialog.Color;
         }
 
         private void cbUserCanDeleteFiles_CheckedChanged(object sender, EventArgs e)

--- a/Switch Backup Manager/FormConfigs.cs
+++ b/Switch Backup Manager/FormConfigs.cs
@@ -89,6 +89,7 @@ namespace Switch_Backup_Manager
             Util.HighlightNSPOnScene = cbHighlightNSPOnScene.Checked;
             Util.HighlightBothOnScene = cbHighlightBothOnScene.Checked;
             Util.HighlightVersionOnXCI = cbHighlightVersionOnXCI.Checked;
+            Util.HighlightMissingNSPUpdate = cbHighlightMissingNSPUpdate.Checked;
             Util.HighlightVersionOnNSP = cbHighlightVersionOnNSP.Checked;
             Util.HighlightXCIOnScene_color = btnColorXCI.BackColor;
             Util.HighlightNSPOnScene_color = btnColorEshop.BackColor;
@@ -99,6 +100,7 @@ namespace Switch_Backup_Manager
             Util.ini.IniWriteValue("Visual", "highlightNSPOnScene", Util.HighlightNSPOnScene ? "true" : "false");
             Util.ini.IniWriteValue("Visual", "highlightBOTHOnScene", Util.HighlightBothOnScene ? "true" : "false");
             Util.ini.IniWriteValue("Visual", "highlightVersionOnXCI", Util.HighlightVersionOnXCI ? "true" : "false");
+            Util.ini.IniWriteValue("Visual", "highlightMissingNSPUpdate", Util.HighlightMissingNSPUpdate ? "true" : "false");
             Util.ini.IniWriteValue("Visual", "highlightVersionOnNSP", Util.HighlightVersionOnNSP ? "true" : "false");
             Util.ini.IniWriteValue("Visual", "highlightXCIOnScene_color", System.Drawing.ColorTranslator.ToHtml(Util.HighlightXCIOnScene_color));
             Util.ini.IniWriteValue("Visual", "highlightNSPOnScene_color", System.Drawing.ColorTranslator.ToHtml(Util.HighlightNSPOnScene_color));
@@ -197,6 +199,7 @@ namespace Switch_Backup_Manager
             cbHighlightNSPOnScene.Checked = Util.HighlightNSPOnScene;
             cbHighlightBothOnScene.Checked = Util.HighlightBothOnScene;
             cbHighlightVersionOnXCI.Checked = Util.HighlightVersionOnXCI;
+            cbHighlightMissingNSPUpdate.Checked = Util.HighlightMissingNSPUpdate;
             cbHighlightVersionOnNSP.Checked = Util.HighlightVersionOnNSP;
             this.btnColorXCI.BackColor = Util.HighlightXCIOnScene_color;
             this.btnColorEshop.BackColor = Util.HighlightNSPOnScene_color;
@@ -401,6 +404,19 @@ namespace Switch_Backup_Manager
             gbCustomNSP.Visible = false;
             this.autoRenamingPatternNSP = "{titleid} - {gamename} - {releasegroup}";
             lblExampleNSP.Text = Util.GetRenamingString(gameExampleNSP, this.autoRenamingPatternNSP);
+        }
+
+        private void cbHighlightVersionOnXCI_CheckedChanged(object sender, EventArgs e)
+        {
+            if (this.cbHighlightVersionOnXCI.Checked)
+            {
+                this.cbHighlightMissingNSPUpdate.Enabled = true;
+            }
+            else
+            {
+                this.cbHighlightMissingNSPUpdate.Checked = false;
+                this.cbHighlightMissingNSPUpdate.Enabled = false;
+            }
         }
 
         private void btnColorXCI_Click(object sender, EventArgs e)

--- a/Switch Backup Manager/FormConfigs.resx
+++ b/Switch Backup Manager/FormConfigs.resx
@@ -59,7 +59,10 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema id="root" 
+    xmlns="" 
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>

--- a/Switch Backup Manager/FormConfigs.resx
+++ b/Switch Backup Manager/FormConfigs.resx
@@ -59,10 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" 
-    xmlns="" 
-    xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
-    xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -2199,7 +2199,7 @@ namespace Switch_Backup_Manager
 
                 if (element != null)
                 {
-                    logger.Info("Removing Title ID " + titleID + " from local eShop database.");
+                    logger.Info("Removing Title ID " + titleID + " from local NSP database.");
                     element.Remove();
                 }
             }

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -21,7 +21,7 @@ namespace Switch_Backup_Manager
 {
     internal static class Util
     {
-        public const string VERSION = "1.2.1";   //Actual application version
+        public const string VERSION = "1.2.2";   //Actual application version
         public const string MIN_DB_Version = "1.2.1"; //This is the minimum version of the DB that can work
 
         public const string INI_FILE = "sbm.ini";
@@ -65,6 +65,7 @@ namespace Switch_Backup_Manager
         public static bool HighlightNSPOnScene = false;
         public static bool HighlightBothOnScene = false;
         public static bool HighlightVersionOnXCI = false;
+        public static bool HighlightMissingNSPUpdate = false;
         public static bool HighlightVersionOnNSP = false;
 
         public static Color HighlightXCIOnScene_color = Color.Green;
@@ -1568,6 +1569,7 @@ namespace Switch_Backup_Manager
             string highlightNSPOnScene = ini.IniReadValue("Visual", "highlightNSPOnScene").Trim().ToLower();
             string highlightBothOnScene = ini.IniReadValue("Visual", "highlightBOTHOnScene").Trim().ToLower();
             string highlightVersionOnXCI = ini.IniReadValue("Visual", "highlightVersionOnXCI").Trim().ToLower();
+            string highlightMissingNSPUpdate = ini.IniReadValue("Visual", "highlightMissingNSPUpdate").Trim().ToLower();
             string highlightVersionOnNSP = ini.IniReadValue("Visual", "highlightVersionOnNSP").Trim().ToLower();
             string highlightXCIOnScene_color = ini.IniReadValue("Visual", "highlightXCIOnScene_color").Trim().ToLower();
             string highlightNSPOnScene_color = ini.IniReadValue("Visual", "highlightNSPOnScene_color").Trim().ToLower();
@@ -1586,6 +1588,7 @@ namespace Switch_Backup_Manager
             if (highlightNSPOnScene != "") { HighlightNSPOnScene = (highlightNSPOnScene == "true"); } else { ini.IniWriteValue("Visual", "highlightNSPOnScene", "false"); };
             if (highlightBothOnScene != "") { HighlightBothOnScene = (highlightBothOnScene == "true"); } else { ini.IniWriteValue("Visual", "highlightBothOnScene", "false"); };
             if (highlightVersionOnXCI != "") { HighlightVersionOnXCI = (highlightVersionOnXCI == "true"); } else { ini.IniWriteValue("Visual", "highlightVersionOnXCI", "false"); };
+            if (highlightMissingNSPUpdate != "") { HighlightMissingNSPUpdate = (highlightMissingNSPUpdate == "true"); } else { ini.IniWriteValue("Visual", "highlightMissingNSPUpdate", "false"); };
             if (highlightVersionOnNSP != "") { HighlightVersionOnNSP = (highlightVersionOnNSP == "true"); } else { ini.IniWriteValue("Visual", "highlightVersionOnNSP", "false"); };
             if (highlightXCIOnScene_color != "") { HighlightXCIOnScene_color = System.Drawing.ColorTranslator.FromHtml(highlightXCIOnScene_color); } else { ini.IniWriteValue("Visual", "highlightXCIOnScene_color", System.Drawing.ColorTranslator.ToHtml(HighlightXCIOnScene_color)); };
             if (highlightNSPOnScene_color != "") { HighlightNSPOnScene_color = System.Drawing.ColorTranslator.FromHtml(highlightNSPOnScene_color); } else { ini.IniWriteValue("Visual", "highlightNSPOnScene_color", System.Drawing.ColorTranslator.ToHtml(HighlightNSPOnScene_color)); };

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -64,10 +64,13 @@ namespace Switch_Backup_Manager
         public static bool HighlightXCIOnScene = false;
         public static bool HighlightNSPOnScene = false;
         public static bool HighlightBothOnScene = false;
+        public static bool HighlightVersionOnXCI = false;
+        public static bool HighlightVersionOnNSP = false;
 
         public static Color HighlightXCIOnScene_color = Color.Green;
         public static Color HighlightNSPOnScene_color = Color.Orange;
         public static Color HighlightBothOnScene_color = Color.Yellow;
+        public static Color HighlightVersion_color = Color.LightPink;
 
         private static string[] Language = new string[16]
         {
@@ -142,7 +145,7 @@ namespace Switch_Backup_Manager
                     string ageVerification = doc.DocumentNode.SelectNodes("//*[@id=\"page-container\"]/div[3]/section/h1/span")[0].InnerText;
                     if (ageVerification.Trim().ToLower() == "age verification")
                     {
-                        logger.Info("This title requires Age Verification!!! Try on GB e-shop");
+                        logger.Info("This title requires Age Verification!!! Try on GB eShop");
                         tryNextCountry = true;
                     }
                 }
@@ -1076,7 +1079,7 @@ namespace Switch_Backup_Manager
         {
             XDocument xml_ = XDocument.Load(@source_xml);
 
-            string removeFrom = (source_xml == LOCAL_FILES_DB ? "local" : "e-shop");
+            string removeFrom = (source_xml == LOCAL_FILES_DB ? "local" : "eShop");
             logger.Info("Started to remove missing files from " + removeFrom + " database");
 
             int i = 0;
@@ -1195,8 +1198,8 @@ namespace Switch_Backup_Manager
             {
                 if (data.DistributionType == "Download")
                 {
-                    data.Cardtype = "e-shop";
-                    data.CartSize = "e-shop";
+                    data.Cardtype = "eShop";
+                    data.CartSize = "eShop";
                 }
             }
         }
@@ -1351,8 +1354,8 @@ namespace Switch_Backup_Manager
         /// </summary>
         /// <param name="xml">XDocument object</param>
         /// <param name="showBaseGames">bool: Include Base games on the list</param>
-        /// <param name="showDLC">bool: Include DLC files on the list</param>
-        /// <param name="showUpdate">bool: Include Update files on the list</param>
+        /// <param name="showDLC">bool: Include DLC files in the list</param>
+        /// <param name="showUpdate">bool: Include Update files in the list</param>
         /// <returns></returns>
         public static Dictionary<Tuple<string, string>, FileData> LoadXMLToFileDataDictionary(XDocument xml, bool showBaseGames, bool showDLC, bool showUpdate)
         {
@@ -1519,7 +1522,7 @@ namespace Switch_Backup_Manager
             UseTitleKeys = (ini.IniReadValue("Config", "useTitleKeys") == "true" ? true : false);
             if (UseTitleKeys && !File.Exists(title_keys))
             {
-                MessageBox.Show(TITLE_KEYS + " not found!\nTo correctly name DLC e-shop files you need to provide a file called " + TITLE_KEYS + " with following format inside: " +
+                MessageBox.Show(TITLE_KEYS + " not found!\nTo correctly name DLC eShop files you need to provide a file called " + TITLE_KEYS + " with following format inside: " +
                     "TitleID|TitleKey|Name.\nIf not provided, game name and other info for DLC will be empty.");
             }
 
@@ -1564,9 +1567,12 @@ namespace Switch_Backup_Manager
             string highlightXCIOnScene = ini.IniReadValue("Visual", "highlightXCIOnScene").Trim().ToLower();
             string highlightNSPOnScene = ini.IniReadValue("Visual", "highlightNSPOnScene").Trim().ToLower();
             string highlightBothOnScene = ini.IniReadValue("Visual", "highlightBOTHOnScene").Trim().ToLower();
+            string highlightVersionOnXCI = ini.IniReadValue("Visual", "highlightVersionOnXCI").Trim().ToLower();
+            string highlightVersionOnNSP = ini.IniReadValue("Visual", "highlightVersionOnNSP").Trim().ToLower();
             string highlightXCIOnScene_color = ini.IniReadValue("Visual", "highlightXCIOnScene_color").Trim().ToLower();
             string highlightNSPOnScene_color = ini.IniReadValue("Visual", "highlightNSPOnScene_color").Trim().ToLower();
             string highlightBothOnScene_color = ini.IniReadValue("Visual", "highlightBOTHOnScene_color").Trim().ToLower();
+            string highlightVersion_color = ini.IniReadValue("Visual", "highlightVersion_color").Trim().ToLower();
 
             if (userCanDeleteFiles != "") { UserCanDeleteFiles = (userCanDeleteFiles == "true"); } else { ini.IniWriteValue("Config", "userCanDeleteFiles", "false"); };
             if (sendDeletedFilesToRecycleBin != "") { SendDeletedFilesToRecycleBin = (sendDeletedFilesToRecycleBin == "true"); } else { ini.IniWriteValue("Config", "sendDeletedFilesToRecycleBin", "true"); };
@@ -1579,10 +1585,12 @@ namespace Switch_Backup_Manager
             if (highlightXCIOnScene != "") { HighlightXCIOnScene = (highlightXCIOnScene == "true"); } else { ini.IniWriteValue("Visual", "highlightXCIOnScene", "false"); };
             if (highlightNSPOnScene != "") { HighlightNSPOnScene = (highlightNSPOnScene == "true"); } else { ini.IniWriteValue("Visual", "highlightNSPOnScene", "false"); };
             if (highlightBothOnScene != "") { HighlightBothOnScene = (highlightBothOnScene == "true"); } else { ini.IniWriteValue("Visual", "highlightBothOnScene", "false"); };
-
+            if (highlightVersionOnXCI != "") { HighlightVersionOnXCI = (highlightVersionOnXCI == "true"); } else { ini.IniWriteValue("Visual", "highlightVersionOnXCI", "false"); };
+            if (highlightVersionOnNSP != "") { HighlightVersionOnNSP = (highlightVersionOnNSP == "true"); } else { ini.IniWriteValue("Visual", "highlightVersionOnNSP", "false"); };
             if (highlightXCIOnScene_color != "") { HighlightXCIOnScene_color = System.Drawing.ColorTranslator.FromHtml(highlightXCIOnScene_color); } else { ini.IniWriteValue("Visual", "highlightXCIOnScene_color", System.Drawing.ColorTranslator.ToHtml(HighlightXCIOnScene_color)); };
             if (highlightNSPOnScene_color != "") { HighlightNSPOnScene_color = System.Drawing.ColorTranslator.FromHtml(highlightNSPOnScene_color); } else { ini.IniWriteValue("Visual", "highlightNSPOnScene_color", System.Drawing.ColorTranslator.ToHtml(HighlightNSPOnScene_color)); };
             if (highlightBothOnScene_color != "") { HighlightBothOnScene_color = System.Drawing.ColorTranslator.FromHtml(highlightBothOnScene_color); } else { ini.IniWriteValue("Visual", "highlightBothOnScene_color", System.Drawing.ColorTranslator.ToHtml(HighlightBothOnScene_color)); };
+            if (highlightVersion_color != "") { HighlightVersion_color = System.Drawing.ColorTranslator.FromHtml(highlightVersion_color); } else { ini.IniWriteValue("Visual", "highlightVersion_color", System.Drawing.ColorTranslator.ToHtml(HighlightVersion_color)); };
 
             try
             {
@@ -2077,7 +2085,7 @@ namespace Switch_Backup_Manager
         }
 
         /// <summary>
-        /// Add all XCI files on a given list to a Dictionary of FileData <TitleID, FileData>
+        /// Add all XCI files in a given list to a Dictionary of FileData <TitleID, FileData>
         /// </summary>
         /// <param name="files string[]">List of files to be appended</param>
         /// <param name="file_type string">valid values: xci, nsp</param>
@@ -2188,7 +2196,7 @@ namespace Switch_Backup_Manager
 
                 if (element != null)
                 {
-                    logger.Info("Removing Title ID " + titleID + " from local e-shop database.");
+                    logger.Info("Removing Title ID " + titleID + " from local eShop database.");
                     element.Remove();
                 }
             }
@@ -2305,8 +2313,8 @@ namespace Switch_Backup_Manager
             data.FileName = Path.GetFileNameWithoutExtension(file);
             data.FileNameWithExt = Path.GetFileName(file);
             data.IsTrimmed = true;
-            data.Cardtype = "e-shop";
-            data.CartSize = "e-shop";
+            data.Cardtype = "eShop";
+            data.CartSize = "eShop";
 
             FileInfo fi = new FileInfo(file);
             //Get File Size


### PR DESCRIPTION
- Reordered main window tabs.
- Renamed visual references of "Local files" to "XCI Files".
- Renamed visual references of "e-shop files" to "NSP Files".
- Renamed most references of "e-shop", "EShop", etc to "eShop" (_Nintendo official spelling_).
- Added version update highlighting in the XCI and NSP lists (_and options to enable/disable_), similar to the "Trimmed" column highlighting:
   - If an XCI has a new version, both the "Version" and the "Latest" column values will be highlighted.
      - Optionally, the highlighting can be disabled if the latest update file exists in the NSP list.
   - If a base NSP has a new version that does not exist in the NSP list, both the "Version" and the "Latest" column values will be highlighted.